### PR TITLE
FLOW-658 | f-popover addition of two more placements

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -4,11 +4,18 @@
 
 # Change Log
 
+## [1.3.2] - 2023-02-16
+
+### Improvements
+
+- `f-popover` two more placements added `left-fixed` and `right-fixed` to fix positions according to parent element towards left and right respectively.
+
 ## [1.3.1] - 2023-02-15
 
 ### Improvements
 
 - `f-form-group` `action` slot added.
+
 ## [1.3.0] - 2023-02-14
 
 ### Bug fixes

--- a/packages/flow-core/custom-elements.json
+++ b/packages/flow-core/custom-elements.json
@@ -837,221 +837,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/f-counter/f-counter.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FCounter",
-          "members": [
-            {
-              "kind": "field",
-              "name": "fill",
-              "type": {
-                "text": "string"
-              },
-              "default": "\"\""
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "number"
-              },
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "\"large\" | \"medium\" | \"small\" | undefined"
-              },
-              "default": "\"medium\"",
-              "attribute": "size"
-            },
-            {
-              "kind": "field",
-              "name": "state",
-              "type": {
-                "text": "FCounterStateProp | undefined"
-              },
-              "default": "\"neutral\"",
-              "attribute": "state"
-            },
-            {
-              "kind": "field",
-              "name": "loading",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "loading"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "disabled"
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "array"
-              },
-              "default": "[\"label\"]",
-              "description": "mention required fields here"
-            },
-            {
-              "kind": "method",
-              "name": "validateProperties"
-            },
-            {
-              "kind": "field",
-              "name": "computedLabel"
-            },
-            {
-              "kind": "method",
-              "name": "abbrNum",
-              "parameters": [
-                {
-                  "name": "number",
-                  "type": {
-                    "text": "number"
-                  }
-                },
-                {
-                  "name": "decPlaces",
-                  "type": {
-                    "text": "number"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "field",
-              "name": "textColor",
-              "description": "compute textColor when custom color of tag is defined."
-            },
-            {
-              "kind": "field",
-              "name": "loaderColor",
-              "description": "compute loaderColor when custom color of tag is defined."
-            },
-            {
-              "kind": "method",
-              "name": "applyStyles",
-              "description": "apply inline styles to shadow-dom for custom fill."
-            },
-            {
-              "kind": "field",
-              "name": "tooltipElement",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "tooltip",
-              "reflects": true,
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "label",
-              "type": {
-                "text": "number"
-              },
-              "fieldName": "label"
-            },
-            {
-              "name": "size",
-              "type": {
-                "text": "\"large\" | \"medium\" | \"small\" | undefined"
-              },
-              "default": "\"medium\"",
-              "fieldName": "size"
-            },
-            {
-              "name": "state",
-              "type": {
-                "text": "FCounterStateProp | undefined"
-              },
-              "default": "\"neutral\"",
-              "fieldName": "state"
-            },
-            {
-              "name": "loading",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "loading"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "tooltip",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "superclass": {
-            "name": "FRoot",
-            "module": "/src/mixins/components/f-root/f-root"
-          },
-          "tagName": "f-counter",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FCounter",
-          "declaration": {
-            "name": "FCounter",
-            "module": "src/components/f-counter/f-counter.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "f-counter",
-          "declaration": {
-            "name": "FCounter",
-            "module": "src/components/f-counter/f-counter.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/f-checkbox/f-checkbox.ts",
       "declarations": [
         {
@@ -1567,6 +1352,221 @@
           "declaration": {
             "name": "FDiv",
             "module": "src/components/f-div/f-div.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/f-counter/f-counter.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FCounter",
+          "members": [
+            {
+              "kind": "field",
+              "name": "fill",
+              "type": {
+                "text": "string"
+              },
+              "default": "\"\""
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "number"
+              },
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "\"large\" | \"medium\" | \"small\" | undefined"
+              },
+              "default": "\"medium\"",
+              "attribute": "size"
+            },
+            {
+              "kind": "field",
+              "name": "state",
+              "type": {
+                "text": "FCounterStateProp | undefined"
+              },
+              "default": "\"neutral\"",
+              "attribute": "state"
+            },
+            {
+              "kind": "field",
+              "name": "loading",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "loading"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "disabled"
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "array"
+              },
+              "default": "[\"label\"]",
+              "description": "mention required fields here"
+            },
+            {
+              "kind": "method",
+              "name": "validateProperties"
+            },
+            {
+              "kind": "field",
+              "name": "computedLabel"
+            },
+            {
+              "kind": "method",
+              "name": "abbrNum",
+              "parameters": [
+                {
+                  "name": "number",
+                  "type": {
+                    "text": "number"
+                  }
+                },
+                {
+                  "name": "decPlaces",
+                  "type": {
+                    "text": "number"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "textColor",
+              "description": "compute textColor when custom color of tag is defined."
+            },
+            {
+              "kind": "field",
+              "name": "loaderColor",
+              "description": "compute loaderColor when custom color of tag is defined."
+            },
+            {
+              "kind": "method",
+              "name": "applyStyles",
+              "description": "apply inline styles to shadow-dom for custom fill."
+            },
+            {
+              "kind": "field",
+              "name": "tooltipElement",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "label",
+              "type": {
+                "text": "number"
+              },
+              "fieldName": "label"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "\"large\" | \"medium\" | \"small\" | undefined"
+              },
+              "default": "\"medium\"",
+              "fieldName": "size"
+            },
+            {
+              "name": "state",
+              "type": {
+                "text": "FCounterStateProp | undefined"
+              },
+              "default": "\"neutral\"",
+              "fieldName": "state"
+            },
+            {
+              "name": "loading",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "loading"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "FRoot",
+            "module": "/src/mixins/components/f-root/f-root"
+          },
+          "tagName": "f-counter",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FCounter",
+          "declaration": {
+            "name": "FCounter",
+            "module": "src/components/f-counter/f-counter.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "f-counter",
+          "declaration": {
+            "name": "FCounter",
+            "module": "src/components/f-counter/f-counter.ts"
           }
         }
       ]

--- a/packages/flow-core/custom-elements.json
+++ b/packages/flow-core/custom-elements.json
@@ -3390,6 +3390,249 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/f-popover/f-popover.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FPopover",
+          "members": [
+            {
+              "kind": "field",
+              "name": "placement",
+              "type": {
+                "text": "FPopoverPlacement | undefined"
+              },
+              "default": "\"auto\"",
+              "attribute": "placement",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "FPopoverSize | undefined"
+              },
+              "default": "\"medium\"",
+              "attribute": "size",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "open",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "open",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "overlay",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "true",
+              "attribute": "overlay",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "target",
+              "type": {
+                "text": "string | HTMLElement"
+              },
+              "attribute": "target",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "cleanup",
+              "type": {
+                "text": "() => void"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "isEscapeClicked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "isTooltip",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "targetElement"
+            },
+            {
+              "kind": "method",
+              "name": "stringToHTML",
+              "parameters": [
+                {
+                  "name": "str",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "computePlacement"
+            },
+            {
+              "kind": "method",
+              "name": "computePosition",
+              "parameters": [
+                {
+                  "name": "isTooltip",
+                  "type": {
+                    "text": "boolean"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "dispatchEsc"
+            },
+            {
+              "kind": "method",
+              "name": "escapekeyHandle",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                },
+                {
+                  "name": "el",
+                  "type": {
+                    "text": "HTMLElement"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "overlayClick"
+            },
+            {
+              "kind": "field",
+              "name": "tooltipElement",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "placement",
+              "type": {
+                "text": "FPopoverPlacement | undefined"
+              },
+              "default": "\"auto\"",
+              "fieldName": "placement"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "FPopoverSize | undefined"
+              },
+              "default": "\"medium\"",
+              "fieldName": "size"
+            },
+            {
+              "name": "open",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "open"
+            },
+            {
+              "name": "overlay",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "true",
+              "fieldName": "overlay"
+            },
+            {
+              "name": "target",
+              "type": {
+                "text": "string | HTMLElement"
+              },
+              "fieldName": "target"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "FRoot",
+            "module": "/src/mixins/components/f-root/f-root"
+          },
+          "tagName": "f-popover",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FPopover",
+          "declaration": {
+            "name": "FPopover",
+            "module": "src/components/f-popover/f-popover.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "f-popover",
+          "declaration": {
+            "name": "FPopover",
+            "module": "src/components/f-popover/f-popover.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/f-radio/f-radio.ts",
       "declarations": [
         {
@@ -4726,249 +4969,6 @@
           "declaration": {
             "name": "FSwitch",
             "module": "src/components/f-switch/f-switch.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/f-popover/f-popover.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FPopover",
-          "members": [
-            {
-              "kind": "field",
-              "name": "placement",
-              "type": {
-                "text": "FPopoverPlacement | undefined"
-              },
-              "default": "\"auto\"",
-              "attribute": "placement",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "FPopoverSize | undefined"
-              },
-              "default": "\"medium\"",
-              "attribute": "size",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "open",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "open",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "overlay",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "true",
-              "attribute": "overlay",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "target",
-              "type": {
-                "text": "string | HTMLElement"
-              },
-              "attribute": "target",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "cleanup",
-              "type": {
-                "text": "() => void"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "isEscapeClicked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "isTooltip",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "targetElement"
-            },
-            {
-              "kind": "method",
-              "name": "stringToHTML",
-              "parameters": [
-                {
-                  "name": "str",
-                  "type": {
-                    "text": "string"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "computePlacement"
-            },
-            {
-              "kind": "method",
-              "name": "computePosition",
-              "parameters": [
-                {
-                  "name": "isTooltip",
-                  "type": {
-                    "text": "boolean"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "dispatchEsc"
-            },
-            {
-              "kind": "method",
-              "name": "escapekeyHandle",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "KeyboardEvent"
-                  }
-                },
-                {
-                  "name": "el",
-                  "type": {
-                    "text": "HTMLElement"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "overlayClick"
-            },
-            {
-              "kind": "field",
-              "name": "tooltipElement",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "tooltip",
-              "reflects": true,
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "placement",
-              "type": {
-                "text": "FPopoverPlacement | undefined"
-              },
-              "default": "\"auto\"",
-              "fieldName": "placement"
-            },
-            {
-              "name": "size",
-              "type": {
-                "text": "FPopoverSize | undefined"
-              },
-              "default": "\"medium\"",
-              "fieldName": "size"
-            },
-            {
-              "name": "open",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "open"
-            },
-            {
-              "name": "overlay",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "true",
-              "fieldName": "overlay"
-            },
-            {
-              "name": "target",
-              "type": {
-                "text": "string | HTMLElement"
-              },
-              "fieldName": "target"
-            },
-            {
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "tooltip",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "superclass": {
-            "name": "FRoot",
-            "module": "/src/mixins/components/f-root/f-root"
-          },
-          "tagName": "f-popover",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FPopover",
-          "declaration": {
-            "name": "FPopover",
-            "module": "src/components/f-popover/f-popover.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "f-popover",
-          "declaration": {
-            "name": "FPopover",
-            "module": "src/components/f-popover/f-popover.ts"
           }
         }
       ]
@@ -6393,43 +6393,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/modules/config/index.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "themeSubject",
-          "default": "new Subject<string>()"
-        },
-        {
-          "kind": "variable",
-          "name": "ConfigUtil",
-          "type": {
-            "text": "object"
-          },
-          "default": "{\n  getConfig() {\n    return config;\n  },\n  setConfig(cfg: Partial<FlowCoreConfig>) {\n    config = { ...config, ...cfg };\n    if (cfg.theme) {\n      this.initTheme();\n    }\n  },\n  initTheme() {\n    document.documentElement.setAttribute(\"data-theme\", `${config.theme}`);\n  },\n}"
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "themeSubject",
-          "declaration": {
-            "name": "themeSubject",
-            "module": "src/modules/config/index.ts"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "ConfigUtil",
-          "declaration": {
-            "name": "ConfigUtil",
-            "module": "src/modules/config/index.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/mixins/svg/checked-mark.ts",
       "declarations": [],
       "exports": [
@@ -6480,6 +6443,43 @@
           "name": "default",
           "declaration": {
             "module": "src/mixins/svg/not-found.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/modules/config/index.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "themeSubject",
+          "default": "new Subject<string>()"
+        },
+        {
+          "kind": "variable",
+          "name": "ConfigUtil",
+          "type": {
+            "text": "object"
+          },
+          "default": "{\n  getConfig() {\n    return config;\n  },\n  setConfig(cfg: Partial<FlowCoreConfig>) {\n    config = { ...config, ...cfg };\n    if (cfg.theme) {\n      this.initTheme();\n    }\n  },\n  initTheme() {\n    document.documentElement.setAttribute(\"data-theme\", `${config.theme}`);\n  },\n}"
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "themeSubject",
+          "declaration": {
+            "name": "themeSubject",
+            "module": "src/modules/config/index.ts"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ConfigUtil",
+          "declaration": {
+            "name": "ConfigUtil",
+            "module": "src/modules/config/index.ts"
           }
         }
       ]

--- a/packages/flow-core/html.html-data.json
+++ b/packages/flow-core/html.html-data.json
@@ -5838,6 +5838,9 @@
               "name": "right-end"
             },
             {
+              "name": "right-fixed"
+            },
+            {
               "name": "bottom-start"
             },
             {
@@ -5848,6 +5851,9 @@
             },
             {
               "name": "left-end"
+            },
+            {
+              "name": "left-fixed"
             }
           ]
         },

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-popover/f-popover.scss
+++ b/packages/flow-core/src/components/f-popover/f-popover.scss
@@ -23,13 +23,31 @@ $sizes: (
 f-popover {
   @include base();
   position: fixed;
+  z-index: 200;
+
+  &[placement="left-fixed"] {
+    position: absolute;
+    z-index: 210;
+    left: 0px;
+    top: 0px;
+    height: 100%;
+    max-height: 100% !important;
+  }
+  &[placement="right-fixed"] {
+    position: absolute;
+    z-index: 210;
+    top: 0px;
+    right: 0px;
+    left: auto;
+    height: 100%;
+    max-height: 100% !important;
+  }
 
   display: flex;
   flex: 0 0 auto;
   background-color: var(--color-surface-tertiary);
   border-radius: 4px;
   overflow: auto;
-  z-index: 200;
   &.tooltip {
     background-color: #000;
     z-index: 1000;

--- a/packages/flow-core/src/components/f-popover/f-popover.ts
+++ b/packages/flow-core/src/components/f-popover/f-popover.ts
@@ -20,12 +20,14 @@ export type FPopoverPlacement =
   | "right"
   | "right-start"
   | "right-end"
+  | "right-fixed"
   | "bottom"
   | "bottom-start"
   | "bottom-end"
   | "left"
   | "left-start"
   | "left-end"
+  | "left-fixed"
   | "auto";
 export type FPopoverSize = "stretch" | "large" | "medium" | "small";
 
@@ -94,7 +96,11 @@ export class FPopover extends FRoot {
     return dom;
   }
   computePlacement() {
-    return this.placement === "auto" ? undefined : this.placement;
+    return this.placement === "auto" ||
+      this.placement === "left-fixed" ||
+      this.placement === "right-fixed"
+      ? undefined
+      : this.placement;
   }
   computePosition(isTooltip: boolean) {
     let target = document.body;
@@ -128,19 +134,21 @@ export class FPopover extends FRoot {
             shift({ padding: isTooltip ? 0 : 16 }),
           ],
         }).then(({ x, y }) => {
-          if (target.nodeName.toLowerCase() !== "body") {
-            Object.assign(this.style, {
-              top: `${y}px`,
-              left: `${x}px`,
-            });
-          } else {
-            const left = (document.body.offsetWidth - this.offsetWidth) / 2;
-            const top = (document.body.offsetHeight - this.offsetHeight) / 2;
+          if (this.placement !== "left-fixed" && this.placement !== "right-fixed") {
+            if (target.nodeName.toLowerCase() !== "body") {
+              Object.assign(this.style, {
+                top: `${y}px`,
+                left: `${x}px`,
+              });
+            } else {
+              const left = (document.body.offsetWidth - this.offsetWidth) / 2;
+              const top = (document.body.offsetHeight - this.offsetHeight) / 2;
 
-            Object.assign(this.style, {
-              top: `${top}px`,
-              left: `${left}px`,
-            });
+              Object.assign(this.style, {
+                top: `${top}px`,
+                left: `${left}px`,
+              });
+            }
           }
         });
       });

--- a/stories/f-popover.stories.mdx
+++ b/stories/f-popover.stories.mdx
@@ -57,9 +57,11 @@ be used to show short-lived information such as menus, options, additional actio
           "right-start",
           "right",
           "right-end",
+          "right-fixed",
           "left-start",
           "left",
           "left-end",
+          "left-fixed",
         ],
       },
       open: {
@@ -195,6 +197,8 @@ By default the popover is auto aligned to the center of the viewport.
     }}
   >
     {(args) => {
+      const [open, setOpen] = useState(false);
+      const [openRight, setOpenRight] = useState(false);
       const [dummyPlacementArray, setDummyPlacementArray] = useState([
         [
           { open: false, title: "Bottom End", placement: "bottom-end" },
@@ -226,7 +230,7 @@ By default the popover is auto aligned to the center of the viewport.
         setDummyPlacementArray(array);
       };
       return html`
-        <f-div height="hug-content" gap="large" direction="column">
+        <f-div height="100%" gap="large" direction="column">
           ${dummyPlacementArray.map((item, index) => {
             return html`
               <f-div height="hug-content" gap="auto" direction="row">
@@ -256,6 +260,42 @@ By default the popover is auto aligned to the center of the viewport.
               </f-div>
             `;
           })}
+          <f-divider></f-divider>
+          <f-div height="fill-container" gap="auto" direction="row">
+            <f-popover
+              ?open=${open}
+              ?overlay=${true}
+              placement="left-fixed"
+              target=${`#left-fixed`}
+              @overlay-click=${() => setOpen(false)}
+            >
+              <f-div state="tertiary" padding="medium">
+                <f-text>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet enim
+                  ut mi egestas, non efficitur odio varius. Phasellus accumsan pellentesque ex
+                  vehicula tristique.
+                </f-text>
+              </f-div>
+            </f-popover>
+            <f-button id="left-fixed" label="left-fixed" @click=${() => setOpen(true)}> </f-button>
+            <f-popover
+              ?open=${openRight}
+              ?overlay=${true}
+              placement="right-fixed"
+              target=${`#right-fixed`}
+              @overlay-click=${() => setOpenRight(false)}
+            >
+              <f-div state="tertiary" padding="medium">
+                <f-text>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet enim
+                  ut mi egestas, non efficitur odio varius. Phasellus accumsan pellentesque ex
+                  vehicula tristique.
+                </f-text>
+              </f-div>
+            </f-popover>
+            <f-button id="right-fixed" label="right-fixed" @click=${() => setOpenRight(true)}>
+            </f-button>
+          </f-div>
         </f-div>
       `;
     }}
@@ -322,6 +362,11 @@ By default the popover is auto aligned to the center of the viewport.
       <td></td>
     </tr>
     <tr>
+      <td>right-fixed</td>
+      <td>position fixed to right according to the parent element</td>
+      <td></td>
+    </tr>
+    <tr>
       <td>left</td>
       <td>placed at left-center position w.r.t the opening button</td>
       <td></td>
@@ -334,6 +379,11 @@ By default the popover is auto aligned to the center of the viewport.
     <tr>
       <td>left-end</td>
       <td>starting from bottom to upwards on left side wrt to the button opening popup</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>left-fixed</td>
+      <td>position fixed to left according to the parent element</td>
       <td></td>
     </tr>
   </tbody>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1405,31 +1405,31 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
-"@cldcvr/flow-aws-icon@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@cldcvr/flow-aws-icon/-/flow-aws-icon-1.0.4.tgz#4eb6abd7cccb574ba1c1afe24b6f3b5cdd93d665"
-  integrity sha512-O5/vfoY/++DZQGY+jYpJT+GFP0V1MbQTqYZ8abT5L4HxHSIBEZB3+uryO+Swn1UGuay2HWd8+RfJYdv/UdoS0w==
+"@cldcvr/flow-aws-icon@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@cldcvr/flow-aws-icon/-/flow-aws-icon-1.0.5.tgz#a5c66190dd81104e195fa2a28907bb2702af1960"
+  integrity sha512-nN3oQlLHRDPblz5QqQ6NsDazgzWuttaXHDeHzzcmJYTVnwY0tADBQLDol7sG1628Tubh0SVp+Bv90CVxYpVeeg==
   dependencies:
     "@cldcvr/flow-core" "*"
 
-"@cldcvr/flow-gcp-icon@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@cldcvr/flow-gcp-icon/-/flow-gcp-icon-1.0.4.tgz#c7c6e53558d1e42a42e45742717c5e79304e3835"
-  integrity sha512-P6XBP0aZ7VqxvWq0lTeu6t6yqB/oJPu8Qz8euyKp6fNvFZtYvrIddmftugz6yrynGqtUctaa01LoOrDFJNglfQ==
+"@cldcvr/flow-gcp-icon@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@cldcvr/flow-gcp-icon/-/flow-gcp-icon-1.0.5.tgz#1134a4f2a30840bf905d69670a4117957a8e2759"
+  integrity sha512-d9/WgvNaKbM1F5jQimems0aTUTaQiwZAtVqH7Iiwbmf7bbNI632pFWH1O1phTJnxClaXHbTzft9Cnjw18ypptw==
   dependencies:
     "@cldcvr/flow-core" "*"
 
-"@cldcvr/flow-product-icon@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@cldcvr/flow-product-icon/-/flow-product-icon-1.0.4.tgz#3edb4cd247f8f883375f55a2d59a58a188aa1e23"
-  integrity sha512-q9IYzfqOLuhnPjQoB0EZRMzTr+bZM7DyLpiIm7NPVJmo6npyaBnc+eE1cfhs2YQOvn0eXKBX5krP9LthyLrBNA==
+"@cldcvr/flow-product-icon@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@cldcvr/flow-product-icon/-/flow-product-icon-1.0.5.tgz#f21eacec10e020e49ece80ef3ac78385bb8876da"
+  integrity sha512-HRHU/n6gA9JJhHHIzOiHwzWQkctsmhOlL8Ftqa15t3NciRT1edeYH1f37e2jtF5JxfzKoVYmSdzzm0SDJjRx2g==
   dependencies:
     "@cldcvr/flow-core" "*"
 
-"@cldcvr/flow-system-icon@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@cldcvr/flow-system-icon/-/flow-system-icon-1.0.4.tgz#73173d72d337d48649741fe5c3307e9a80067314"
-  integrity sha512-bSZxMICI3RPTHWi1J55ADa9xWt3O0X2mS22MxKnOYJSCgM9tREW5F++HPMs94IjPcffyGrgAxarZrppjUhK5qw==
+"@cldcvr/flow-system-icon@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@cldcvr/flow-system-icon/-/flow-system-icon-1.0.5.tgz#815f636aa7a79277e889e8e7f35ab5d7f46d453d"
+  integrity sha512-vDUJR2lNAt94vAewDbmb16gBXv2QcmSaUqbitQMIbCvoZEQtUgUghGpd1xx8IiWxOId5EnERDSZvtiP7RCyGaA==
   dependencies:
     "@cldcvr/flow-core" "*"
 


### PR DESCRIPTION
### Checklist for raising a PR
- [x] Gone through UX documnetation for adding new features.
- [x] All necessary unit tests covered.
- [x] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [x] Did you check the contributing doc?
- [x] Did you check the existing issues for similar queries?


### Describe your PR
- `f-popover` two more placements added `left-fixed` and `right-fixed` to fix positions according to parent element towards left and right respectively.

<img width="1678" alt="Screenshot 2023-02-16 at 2 52 30 PM" src="https://user-images.githubusercontent.com/23555670/219323119-1331c21f-0c2a-421a-b9a1-e8eef73f28eb.png">
<img width="1672" alt="Screenshot 2023-02-16 at 2 52 45 PM" src="https://user-images.githubusercontent.com/23555670/219323158-9b8e207e-51cf-4d2b-b488-8ffe40103c5d.png">
<img width="1679" alt="Screenshot 2023-02-16 at 2 52 58 PM" src="https://user-images.githubusercontent.com/23555670/219323171-3b87193c-94bc-4a87-a41c-54810daa29b4.png">



### Add additional question here
- [ ] `Yes`
- [x] `No`
- [ ] `NA`