### PR TITLE
FLOW-917 f-popover custom size

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 # Change Log
 
+## [1.25.0] - 2023-09-14
+
+### Features
+
+- `f-popover` size property now supports custom size .Ex `size="custom(500px,100vh)"`
+- `f-popover` can open without target with custom placements. Ex. `size="custom(500px,100vh)" placement="right"` this will open popover on extreme right like slideout.
+### Bug Fixes
+- `f-popover` : `@overlay-click` not emitted when `:overlay="false"`
 ## [1.24.9] - 2023-09-13
 
 ### Bug Fixes

--- a/packages/flow-core/custom-elements.json
+++ b/packages/flow-core/custom-elements.json
@@ -951,6 +951,292 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/f-breadcrumb/f-breadcrumb.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FBreadcrumb",
+          "members": [
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "\"medium\" | \"small\" | undefined"
+              },
+              "default": "\"medium\"",
+              "attribute": "size",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "crumbs",
+              "type": {
+                "text": "FBreadcrumbs"
+              },
+              "attribute": "crumbs"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "popOverElement",
+              "type": {
+                "text": "FPopover"
+              },
+              "description": "popover element reference"
+            },
+            {
+              "kind": "field",
+              "name": "breadCrumbPopover",
+              "type": {
+                "text": "FDiv"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "initialCrumbs",
+              "type": {
+                "text": "FBreadCrumbsProp"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "middlePopoverCrumbs",
+              "type": {
+                "text": "FBreadcrumbs"
+              },
+              "default": "[]"
+            },
+            {
+              "kind": "field",
+              "name": "endingCrumbs",
+              "type": {
+                "text": "FBreadcrumbs"
+              },
+              "default": "[]"
+            },
+            {
+              "kind": "field",
+              "name": "textSize",
+              "description": "text size computed",
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "isCurrentCrumb",
+              "parameters": [
+                {
+                  "name": "index",
+                  "type": {
+                    "text": "number"
+                  },
+                  "description": "index number of crumbs"
+                },
+                {
+                  "name": "array",
+                  "type": {
+                    "text": "FBreadcrumbs"
+                  },
+                  "description": "crumbs array"
+                }
+              ],
+              "return": {
+                "type": {
+                  "text": ""
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "createSeperateCrumbs",
+              "description": "create seperate crumbs when crumbs length is greater than 4"
+            },
+            {
+              "kind": "method",
+              "name": "crumbLoop",
+              "parameters": [
+                {
+                  "name": "crumb",
+                  "type": {
+                    "text": "FBreadCrumbsProp"
+                  }
+                },
+                {
+                  "name": "index",
+                  "type": {
+                    "text": "number"
+                  }
+                },
+                {
+                  "name": "array",
+                  "type": {
+                    "text": "FBreadcrumbs"
+                  }
+                }
+              ],
+              "return": {
+                "type": {
+                  "text": ""
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "togglePopover",
+              "parameters": [
+                {
+                  "name": "action",
+                  "type": {
+                    "text": "\"open\" | \"close\""
+                  },
+                  "description": "action whether to close or open popover"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleDispatchEvent",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "MouseEvent"
+                  },
+                  "description": "event"
+                },
+                {
+                  "name": "value",
+                  "type": {
+                    "text": "FBreadCrumbsProp"
+                  },
+                  "description": "crumb value"
+                }
+              ],
+              "description": "dispatch click event"
+            },
+            {
+              "kind": "field",
+              "name": "tooltipElement",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mouseEnter",
+              "type": {
+                "text": "() => void | undefined"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mouseLeave",
+              "type": {
+                "text": "() => void | undefined"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "isMouseOver",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "size",
+              "type": {
+                "text": "\"medium\" | \"small\" | undefined"
+              },
+              "default": "\"medium\"",
+              "fieldName": "size"
+            },
+            {
+              "name": "crumbs",
+              "type": {
+                "text": "FBreadcrumbs"
+              },
+              "fieldName": "crumbs"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "FRoot",
+            "module": "/src/mixins/components/f-root/f-root"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FBreadcrumb",
+          "declaration": {
+            "name": "FBreadcrumb",
+            "module": "src/components/f-breadcrumb/f-breadcrumb.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/f-button/f-button.ts",
       "declarations": [
         {
@@ -1289,292 +1575,6 @@
           "declaration": {
             "name": "FButton",
             "module": "src/components/f-button/f-button.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/f-breadcrumb/f-breadcrumb.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FBreadcrumb",
-          "members": [
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "\"medium\" | \"small\" | undefined"
-              },
-              "default": "\"medium\"",
-              "attribute": "size",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "crumbs",
-              "type": {
-                "text": "FBreadcrumbs"
-              },
-              "attribute": "crumbs"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "popOverElement",
-              "type": {
-                "text": "FPopover"
-              },
-              "description": "popover element reference"
-            },
-            {
-              "kind": "field",
-              "name": "breadCrumbPopover",
-              "type": {
-                "text": "FDiv"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "initialCrumbs",
-              "type": {
-                "text": "FBreadCrumbsProp"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "middlePopoverCrumbs",
-              "type": {
-                "text": "FBreadcrumbs"
-              },
-              "default": "[]"
-            },
-            {
-              "kind": "field",
-              "name": "endingCrumbs",
-              "type": {
-                "text": "FBreadcrumbs"
-              },
-              "default": "[]"
-            },
-            {
-              "kind": "field",
-              "name": "textSize",
-              "description": "text size computed",
-              "readonly": true
-            },
-            {
-              "kind": "method",
-              "name": "isCurrentCrumb",
-              "parameters": [
-                {
-                  "name": "index",
-                  "type": {
-                    "text": "number"
-                  },
-                  "description": "index number of crumbs"
-                },
-                {
-                  "name": "array",
-                  "type": {
-                    "text": "FBreadcrumbs"
-                  },
-                  "description": "crumbs array"
-                }
-              ],
-              "return": {
-                "type": {
-                  "text": ""
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "createSeperateCrumbs",
-              "description": "create seperate crumbs when crumbs length is greater than 4"
-            },
-            {
-              "kind": "method",
-              "name": "crumbLoop",
-              "parameters": [
-                {
-                  "name": "crumb",
-                  "type": {
-                    "text": "FBreadCrumbsProp"
-                  }
-                },
-                {
-                  "name": "index",
-                  "type": {
-                    "text": "number"
-                  }
-                },
-                {
-                  "name": "array",
-                  "type": {
-                    "text": "FBreadcrumbs"
-                  }
-                }
-              ],
-              "return": {
-                "type": {
-                  "text": ""
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "togglePopover",
-              "parameters": [
-                {
-                  "name": "action",
-                  "type": {
-                    "text": "\"open\" | \"close\""
-                  },
-                  "description": "action whether to close or open popover"
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handleDispatchEvent",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "MouseEvent"
-                  },
-                  "description": "event"
-                },
-                {
-                  "name": "value",
-                  "type": {
-                    "text": "FBreadCrumbsProp"
-                  },
-                  "description": "crumb value"
-                }
-              ],
-              "description": "dispatch click event"
-            },
-            {
-              "kind": "field",
-              "name": "tooltipElement",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "tooltip",
-              "reflects": true,
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "mouseEnter",
-              "type": {
-                "text": "() => void | undefined"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "mouseLeave",
-              "type": {
-                "text": "() => void | undefined"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "isMouseOver",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "size",
-              "type": {
-                "text": "\"medium\" | \"small\" | undefined"
-              },
-              "default": "\"medium\"",
-              "fieldName": "size"
-            },
-            {
-              "name": "crumbs",
-              "type": {
-                "text": "FBreadcrumbs"
-              },
-              "fieldName": "crumbs"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "tooltip",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "superclass": {
-            "name": "FRoot",
-            "module": "/src/mixins/components/f-root/f-root"
-          }
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FBreadcrumb",
-          "declaration": {
-            "name": "FBreadcrumb",
-            "module": "src/components/f-breadcrumb/f-breadcrumb.ts"
           }
         }
       ]
@@ -2013,6 +2013,198 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/f-checkbox/f-checkbox.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FCheckbox",
+          "members": [
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "\"checked\" | \"unchecked\" | \"indeterminate\" | undefined"
+              },
+              "default": "\"unchecked\"",
+              "attribute": "value",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "state",
+              "type": {
+                "text": "FCheckboxState | undefined"
+              },
+              "default": "\"default\"",
+              "attribute": "state",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "\"small\" | \"medium\" | undefined"
+              },
+              "attribute": "size",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "slotWrapper",
+              "type": {
+                "text": "FDiv"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "handleInput",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "InputEvent"
+                  }
+                }
+              ],
+              "description": "emit event."
+            },
+            {
+              "kind": "method",
+              "name": "checkSlots"
+            },
+            {
+              "kind": "field",
+              "name": "tooltipElement",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mouseEnter",
+              "type": {
+                "text": "() => void | undefined"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mouseLeave",
+              "type": {
+                "text": "() => void | undefined"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "isMouseOver",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "value",
+              "type": {
+                "text": "\"checked\" | \"unchecked\" | \"indeterminate\" | undefined"
+              },
+              "default": "\"unchecked\"",
+              "fieldName": "value"
+            },
+            {
+              "name": "state",
+              "type": {
+                "text": "FCheckboxState | undefined"
+              },
+              "default": "\"default\"",
+              "fieldName": "state"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "\"small\" | \"medium\" | undefined"
+              },
+              "fieldName": "size"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "FRoot",
+            "module": "/src/mixins/components/f-root/f-root"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FCheckbox",
+          "declaration": {
+            "name": "FCheckbox",
+            "module": "src/components/f-checkbox/f-checkbox.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/f-counter/f-counter.ts",
       "declarations": [
         {
@@ -2268,198 +2460,6 @@
           "declaration": {
             "name": "FCounter",
             "module": "src/components/f-counter/f-counter.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/f-checkbox/f-checkbox.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FCheckbox",
-          "members": [
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "\"checked\" | \"unchecked\" | \"indeterminate\" | undefined"
-              },
-              "default": "\"unchecked\"",
-              "attribute": "value",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "state",
-              "type": {
-                "text": "FCheckboxState | undefined"
-              },
-              "default": "\"default\"",
-              "attribute": "state",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "\"small\" | \"medium\" | undefined"
-              },
-              "attribute": "size",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "slotWrapper",
-              "type": {
-                "text": "FDiv"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "handleInput",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "InputEvent"
-                  }
-                }
-              ],
-              "description": "emit event."
-            },
-            {
-              "kind": "method",
-              "name": "checkSlots"
-            },
-            {
-              "kind": "field",
-              "name": "tooltipElement",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "tooltip",
-              "reflects": true,
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "mouseEnter",
-              "type": {
-                "text": "() => void | undefined"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "mouseLeave",
-              "type": {
-                "text": "() => void | undefined"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "isMouseOver",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "value",
-              "type": {
-                "text": "\"checked\" | \"unchecked\" | \"indeterminate\" | undefined"
-              },
-              "default": "\"unchecked\"",
-              "fieldName": "value"
-            },
-            {
-              "name": "state",
-              "type": {
-                "text": "FCheckboxState | undefined"
-              },
-              "default": "\"default\"",
-              "fieldName": "state"
-            },
-            {
-              "name": "size",
-              "type": {
-                "text": "\"small\" | \"medium\" | undefined"
-              },
-              "fieldName": "size"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "tooltip",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "superclass": {
-            "name": "FRoot",
-            "module": "/src/mixins/components/f-root/f-root"
-          }
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FCheckbox",
-          "declaration": {
-            "name": "FCheckbox",
-            "module": "src/components/f-checkbox/f-checkbox.ts"
           }
         }
       ]
@@ -4392,6 +4392,141 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/f-form/f-form.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FForm",
+          "members": [
+            {
+              "kind": "field",
+              "name": "gap",
+              "type": {
+                "text": "\"large\" | \"medium\" | \"small\" | \"x-small\" | undefined"
+              },
+              "default": "\"medium\"",
+              "attribute": "gap",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "separator",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "separator",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "tooltipElement",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "attribute": "tooltip",
+              "reflects": true,
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mouseEnter",
+              "type": {
+                "text": "() => void | undefined"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "mouseLeave",
+              "type": {
+                "text": "() => void | undefined"
+              },
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "isMouseOver",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "gap",
+              "type": {
+                "text": "\"large\" | \"medium\" | \"small\" | \"x-small\" | undefined"
+              },
+              "default": "\"medium\"",
+              "fieldName": "gap"
+            },
+            {
+              "name": "separator",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "separator"
+            },
+            {
+              "name": "tooltip",
+              "type": {
+                "text": "string | undefined"
+              },
+              "fieldName": "tooltip",
+              "inheritedFrom": {
+                "name": "FRoot",
+                "module": "src/mixins/components/f-root/f-root.ts"
+              }
+            }
+          ],
+          "superclass": {
+            "name": "FRoot",
+            "module": "/src/mixins/components/f-root/f-root"
+          },
+          "summary": "Text component includes Headings, titles, body texts and links."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FForm",
+          "declaration": {
+            "name": "FForm",
+            "module": "src/components/f-form/f-form.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/f-file-upload/f-file-upload.ts",
       "declarations": [
         {
@@ -4947,141 +5082,6 @@
           "declaration": {
             "name": "FFileUpload",
             "module": "src/components/f-file-upload/f-file-upload.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/f-form/f-form.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FForm",
-          "members": [
-            {
-              "kind": "field",
-              "name": "gap",
-              "type": {
-                "text": "\"large\" | \"medium\" | \"small\" | \"x-small\" | undefined"
-              },
-              "default": "\"medium\"",
-              "attribute": "gap",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "separator",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "separator",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "tooltipElement",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "attribute": "tooltip",
-              "reflects": true,
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "mouseEnter",
-              "type": {
-                "text": "() => void | undefined"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "mouseLeave",
-              "type": {
-                "text": "() => void | undefined"
-              },
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "isMouseOver",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "gap",
-              "type": {
-                "text": "\"large\" | \"medium\" | \"small\" | \"x-small\" | undefined"
-              },
-              "default": "\"medium\"",
-              "fieldName": "gap"
-            },
-            {
-              "name": "separator",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "separator"
-            },
-            {
-              "name": "tooltip",
-              "type": {
-                "text": "string | undefined"
-              },
-              "fieldName": "tooltip",
-              "inheritedFrom": {
-                "name": "FRoot",
-                "module": "src/mixins/components/f-root/f-root.ts"
-              }
-            }
-          ],
-          "superclass": {
-            "name": "FRoot",
-            "module": "/src/mixins/components/f-root/f-root"
-          },
-          "summary": "Text component includes Headings, titles, body texts and links."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FForm",
-          "declaration": {
-            "name": "FForm",
-            "module": "src/components/f-form/f-form.ts"
           }
         }
       ]
@@ -7009,6 +7009,10 @@
             },
             {
               "kind": "field",
+              "name": "escapeHandler"
+            },
+            {
+              "kind": "field",
               "name": "isTooltip",
               "type": {
                 "text": "boolean"
@@ -7062,6 +7066,10 @@
                   }
                 }
               ]
+            },
+            {
+              "kind": "method",
+              "name": "getBodyTargetPlacementCords"
             },
             {
               "kind": "method",
@@ -12270,88 +12278,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/f-tooltip/f-tooltip.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FTooltip",
-          "members": [
-            {
-              "kind": "field",
-              "name": "open",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "local attribute for opem/close of tooltip"
-            },
-            {
-              "kind": "field",
-              "name": "placement",
-              "type": {
-                "text": "FTooltipPlacement | undefined"
-              },
-              "default": "\"auto\"",
-              "attribute": "placement",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "closable",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "attribute": "closable",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "target",
-              "type": {
-                "text": "string | HTMLElement"
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "placement",
-              "type": {
-                "text": "FTooltipPlacement | undefined"
-              },
-              "default": "\"auto\"",
-              "fieldName": "placement"
-            },
-            {
-              "name": "closable",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "default": "false",
-              "fieldName": "closable"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FTooltip",
-          "declaration": {
-            "name": "FTooltip",
-            "module": "src/components/f-tooltip/f-tooltip.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/f-toast/f-toast-queue.ts",
       "declarations": [],
       "exports": [
@@ -12626,6 +12552,88 @@
           "declaration": {
             "name": "FToast",
             "module": "src/components/f-toast/f-toast.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/f-tooltip/f-tooltip.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FTooltip",
+          "members": [
+            {
+              "kind": "field",
+              "name": "open",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "local attribute for opem/close of tooltip"
+            },
+            {
+              "kind": "field",
+              "name": "placement",
+              "type": {
+                "text": "FTooltipPlacement | undefined"
+              },
+              "default": "\"auto\"",
+              "attribute": "placement",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "closable",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "attribute": "closable",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "target",
+              "type": {
+                "text": "string | HTMLElement"
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "placement",
+              "type": {
+                "text": "FTooltipPlacement | undefined"
+              },
+              "default": "\"auto\"",
+              "fieldName": "placement"
+            },
+            {
+              "name": "closable",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "default": "false",
+              "fieldName": "closable"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FTooltip",
+          "declaration": {
+            "name": "FTooltip",
+            "module": "src/components/f-tooltip/f-tooltip.ts"
           }
         }
       ]

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "1.24.9",
+  "version": "1.25.0",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-popover/f-popover.scss
+++ b/packages/flow-core/src/components/f-popover/f-popover.scss
@@ -34,6 +34,12 @@ f-popover {
 		background-color: #000;
 		z-index: 1000;
 	}
+	&.f-popover-custom-size {
+		--custom-width: none;
+		--custom-height: none;
+		width: var(--custom-width) !important;
+		height: var(--custom-height) !important;
+	}
 
 	&[open] {
 		@each $size, $value in $sizes {
@@ -70,5 +76,8 @@ f-popover {
 		right: 0px;
 		left: 0px;
 		z-index: 1;
+		&[data-transparent="true"] {
+			background-color: transparent;
+		}
 	}
 }

--- a/packages/flow-core/src/components/f-popover/f-popover.test.ts
+++ b/packages/flow-core/src/components/f-popover/f-popover.test.ts
@@ -4,32 +4,30 @@ import "@cldcvr/flow-core";
 import { FPopover } from "@cldcvr/flow-core";
 
 describe("f-popover", () => {
-  it("is defined", () => {
-    const el = document.createElement("f-popover");
-    expect(el).instanceOf(FPopover);
-  });
-  it("should render open popover ", async () => {
-    const el = await fixture(html` <f-popover open>Test</f-popover> `);
-    expect(el.textContent?.trim()).to.equal("Test");
-    const descendant = el.shadowRoot!.querySelector(".f-overlay")!;
-    expect(descendant).not.null;
-  });
-  it("should render closed popover ", async () => {
-    const el = await fixture(html` <f-popover>Test</f-popover> `);
-    expect(el.textContent?.trim()).to.equal("Test");
-    const descendant = el.shadowRoot!.querySelector(".f-overlay")!;
-    expect(descendant).is.null;
-  });
-  it("should render without overlay ", async () => {
-    const el = await fixture(
-      html` <f-popover open .overlay=${false}>Test</f-popover> `
-    );
-    expect(el.textContent?.trim()).to.equal("Test");
-    const descendant = el.shadowRoot!.querySelector(".f-overlay")!;
-    expect(descendant).is.null;
-  });
-  it("should render with default size ", async () => {
-    const el = await fixture(html` <f-popover open>Test</f-popover> `);
-    expect(el.getAttribute("size")).to.equal("medium");
-  });
+	it("is defined", () => {
+		const el = document.createElement("f-popover");
+		expect(el).instanceOf(FPopover);
+	});
+	it("should render open popover ", async () => {
+		const el = await fixture(html` <f-popover open>Test</f-popover> `);
+		expect(el.textContent?.trim()).to.equal("Test");
+		const descendant = el.shadowRoot!.querySelector(".f-overlay")!;
+		expect(descendant).not.null;
+	});
+	it("should render closed popover ", async () => {
+		const el = await fixture(html` <f-popover>Test</f-popover> `);
+		expect(el.textContent?.trim()).to.equal("Test");
+		const descendant = el.shadowRoot!.querySelector(".f-overlay")!;
+		expect(descendant).is.null;
+	});
+	it("should render without overlay ", async () => {
+		const el = await fixture(html` <f-popover open .overlay=${false}>Test</f-popover> `);
+		expect(el.textContent?.trim()).to.equal("Test");
+		const descendant = el.shadowRoot!.querySelector<HTMLElement>(".f-overlay")!;
+		expect(descendant.dataset["transparent"]).to.equal("true");
+	});
+	it("should render with default size ", async () => {
+		const el = await fixture(html` <f-popover open>Test</f-popover> `);
+		expect(el.getAttribute("size")).to.equal("medium");
+	});
 });

--- a/packages/flow-core/src/components/f-popover/f-popover.ts
+++ b/packages/flow-core/src/components/f-popover/f-popover.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-mixed-spaces-and-tabs */
-import { html, LitElement, PropertyValueMap, unsafeCSS } from "lit";
+import { html, LitElement, nothing, PropertyValueMap, unsafeCSS } from "lit";
 import { property, state } from "lit/decorators.js";
 import { FRoot } from "../../mixins/components/f-root/f-root";
 import eleStyle from "./f-popover.scss";
@@ -29,7 +29,23 @@ export type FPopoverPlacement =
 	| "left-start"
 	| "left-end"
 	| "auto";
-export type FPopoverSize = "stretch" | "large" | "medium" | "small";
+export type FPopoverSize = "stretch" | "large" | "medium" | "small" | FPopoverCustomSize;
+
+export type FPopoverCustomWidth =
+	| `${number}px`
+	| `${number}%`
+	| `${number}vw`
+	| `auto`
+	| `fit-content`;
+
+export type FPopoverCustomHeight =
+	| `${number}px`
+	| `${number}%`
+	| `${number}vh`
+	| `auto`
+	| `fit-content`;
+
+export type FPopoverCustomSize = `custom(${FPopoverCustomWidth},${FPopoverCustomHeight})`;
 
 export type FPopOverOffset = {
 	mainAxis: number;
@@ -98,6 +114,8 @@ export class FPopover extends FRoot {
 	@state()
 	isEscapeClicked = false;
 
+	escapeHandler = (e: KeyboardEvent) => this.escapekeyHandle(e, this);
+
 	isTooltip = false;
 
 	reqAniFrame?: number;
@@ -128,6 +146,16 @@ export class FPopover extends FRoot {
 			target = this.targetElement;
 		}
 		if (this.open) {
+			if (this.size && this.size?.includes("custom")) {
+				const regex = /\((.*)\)/i;
+				const matches = this.size.match(regex);
+				if (matches) {
+					const [width, height] = matches[1].split(",");
+					this.classList.add("f-popover-custom-size");
+					this.style.setProperty("--custom-width", width);
+					this.style.setProperty("--custom-height", height);
+				}
+			}
 			this.cleanup = autoUpdate(target, this, () => {
 				computePosition(target, this, {
 					placement: this.computePlacement(),
@@ -176,13 +204,7 @@ export class FPopover extends FRoot {
 							left: `${x}px`
 						});
 					} else {
-						const left = (document.body.offsetWidth - this.offsetWidth) / 2;
-						const top = (document.body.offsetHeight - this.offsetHeight) / 2;
-
-						Object.assign(this.style, {
-							top: `${top}px`,
-							left: `${left}px`
-						});
+						Object.assign(this.style, this.getBodyTargetPlacementCords());
 					}
 
 					this.querySelectorAll("f-popover").forEach(async pop => {
@@ -192,11 +214,91 @@ export class FPopover extends FRoot {
 			});
 		}
 	}
+
+	getBodyTargetPlacementCords() {
+		if (this.placement?.includes("top")) {
+			let left: number | undefined = (document.body.offsetWidth - this.offsetWidth) / 2;
+			const top = 0;
+			let right = undefined;
+			if (this.placement?.includes("start")) {
+				left = 0;
+				right = undefined;
+			}
+			if (this.placement?.includes("end")) {
+				right = 0;
+				left = undefined;
+			}
+			return {
+				top: `${top}px`,
+				left: left ? `${left}px` : left,
+				right: right ? `${right}px` : right
+			};
+		} else if (this.placement?.includes("bottom")) {
+			let left: number | undefined = (document.body.offsetWidth - this.offsetWidth) / 2;
+			const bottom = 0;
+			let right = undefined;
+			if (this.placement?.includes("start")) {
+				left = 0;
+				right = undefined;
+			}
+			if (this.placement?.includes("end")) {
+				right = 0;
+				left = undefined;
+			}
+			return {
+				bottom: `${bottom}px`,
+				left: left ? `${left}px` : left,
+				right: right ? `${right}px` : right
+			};
+		} else if (this.placement?.includes("right")) {
+			let bottom: number | undefined = undefined;
+			let top: number | undefined = (document.body.offsetHeight - this.offsetHeight) / 2;
+			const right = 0;
+			if (this.placement?.includes("start")) {
+				top = 0;
+				bottom = undefined;
+			}
+			if (this.placement?.includes("end")) {
+				bottom = 0;
+				top = undefined;
+			}
+			return {
+				right: `${right}px`,
+				bottom: bottom ? `${bottom}px` : bottom,
+				top: top ? `${top}px` : top
+			};
+		} else if (this.placement?.includes("left")) {
+			let bottom: number | undefined = undefined;
+			let top: number | undefined = (document.body.offsetHeight - this.offsetHeight) / 2;
+			const left = 0;
+			if (this.placement?.includes("start")) {
+				top = 0;
+				bottom = undefined;
+			}
+			if (this.placement?.includes("end")) {
+				bottom = 0;
+				top = undefined;
+			}
+			return {
+				left: `${left}px`,
+				bottom: bottom ? `${bottom}px` : bottom,
+				top: top ? `${top}px` : top
+			};
+		} else {
+			const left = (document.body.offsetWidth - this.offsetWidth) / 2;
+			const top = (document.body.offsetHeight - this.offsetHeight) / 2;
+
+			return {
+				top: `${top}px`,
+				left: `${left}px`
+			};
+		}
+	}
 	disconnectedCallback() {
 		if (this.cleanup) {
 			this.cleanup();
 		}
-		document.removeEventListener("keydown", e => this.escapekeyHandle(e, this));
+		document.removeEventListener("keydown", this.escapeHandler);
 		this.removeEventListener("click", this.dispatchEsc);
 		super.disconnectedCallback();
 		// clear request animation frame if any
@@ -210,7 +312,7 @@ export class FPopover extends FRoot {
 
 	connectedCallback() {
 		super.connectedCallback();
-		document.addEventListener("keydown", e => this.escapekeyHandle(e, this));
+		document.addEventListener("keydown", this.escapeHandler);
 		this.addEventListener("click", this.dispatchEsc);
 	}
 	dispatchEsc() {
@@ -227,6 +329,7 @@ export class FPopover extends FRoot {
 			this.dispatchEvent(event);
 		}
 	}
+
 	escapekeyHandle(e: KeyboardEvent, el: HTMLElement) {
 		if (e.key === "Escape") {
 			this.isEscapeClicked = true;
@@ -253,14 +356,24 @@ export class FPopover extends FRoot {
 			}
 		});
 		if (this.open) {
-			const overlay = this.overlay
-				? html`<div class="f-overlay" data-qa-overlay @click=${this.overlayClick}></div>`
-				: "";
+			const overlay = this.isTooltip
+				? nothing
+				: html`<div
+						class="f-overlay"
+						data-transparent=${!this.overlay}
+						data-qa-overlay
+						@click=${this.overlayClick}
+				  ></div>`;
 			this.computePosition(this.isTooltip);
 			return html`<slot></slot>${overlay} `;
 		} else {
 			if (this.targetElement) {
 				this.targetElement.style.removeProperty("z-index");
+			}
+			if (this.size && this.size?.includes("custom")) {
+				this.classList.remove("f-popover-custom-size");
+				this.style.setProperty("--custom-width", null);
+				this.style.setProperty("--custom-height", null);
 			}
 		}
 		return ``;
@@ -276,13 +389,15 @@ export class FPopover extends FRoot {
 			cancelAnimationFrame(this.reqAniFrame);
 		}
 		this.reqAniFrame = requestAnimationFrame(() => {
-			if (this.autoHeight && this.open) {
-				const topPosition = Number(this.style.top.replace("px", "")) + 16;
-				this.style.height = `calc(100vh - ${topPosition}px)`;
-				this.style.maxHeight = `calc(100vh - ${topPosition}px)`;
-			} else {
-				this.style.removeProperty("height");
-				this.style.removeProperty("max-height");
+			if (!this.size?.includes("custom")) {
+				if (this.autoHeight && this.open) {
+					const topPosition = Number(this.style.top.replace("px", "")) + 16;
+					this.style.height = `calc(100vh - ${topPosition}px)`;
+					this.style.maxHeight = `calc(100vh - ${topPosition}px)`;
+				} else {
+					this.style.removeProperty("height");
+					this.style.removeProperty("max-height");
+				}
 			}
 		});
 	}

--- a/packages/flow-table/CHANGELOG.md
+++ b/packages/flow-table/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 # Change Log
 
+## [1.3.2] - 2023-09-13
+
+### Bug Fixes
+
+- `f-table-schema` : cell with template not taking full width.
+
 ## [1.3.1] - 2023-09-13
 
 ### Improvements

--- a/packages/flow-table/custom-elements.json
+++ b/packages/flow-table/custom-elements.json
@@ -589,6 +589,12 @@
                   "type": {
                     "text": "FTableSchemaCell"
                   }
+                },
+                {
+                  "name": "highlightTerm",
+                  "type": {
+                    "text": "string | null"
+                  }
                 }
               ]
             },
@@ -747,6 +753,166 @@
           "declaration": {
             "name": "FTableSchema",
             "module": "src/components/f-table-schema/f-table-schema.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/f-trow/f-trow.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "",
+          "name": "FTrow",
+          "members": [
+            {
+              "kind": "field",
+              "name": "state",
+              "type": {
+                "text": "FTrowState | undefined"
+              },
+              "default": "\"default\"",
+              "attribute": "state",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "open",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "attribute": "open",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "selected",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "attribute": "selected",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "expandIconPosition",
+              "type": {
+                "text": "FTrowChevronPosition | undefined"
+              },
+              "default": "\"right\"",
+              "attribute": "expand-icon-position",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "disableSelection",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "attribute": "disable-selection",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "expndablePanel",
+              "type": {
+                "text": "FTcell | undefined"
+              }
+            },
+            {
+              "kind": "field",
+              "name": "detailsSlotElement",
+              "type": {
+                "text": "HTMLSlotElement"
+              }
+            },
+            {
+              "kind": "method",
+              "name": "propogateProps",
+              "description": "propogate props related to chevron and checkbox and radio boxes"
+            },
+            {
+              "kind": "method",
+              "name": "toggleDetails",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "CustomEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleInput",
+              "parameters": [
+                {
+                  "name": "event",
+                  "type": {
+                    "text": "CustomEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "handleDetailsSlot"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "state",
+              "type": {
+                "text": "FTrowState | undefined"
+              },
+              "default": "\"default\"",
+              "fieldName": "state"
+            },
+            {
+              "name": "open",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "fieldName": "open"
+            },
+            {
+              "name": "selected",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "fieldName": "selected"
+            },
+            {
+              "name": "expand-icon-position",
+              "type": {
+                "text": "FTrowChevronPosition | undefined"
+              },
+              "default": "\"right\"",
+              "fieldName": "expandIconPosition"
+            },
+            {
+              "name": "disable-selection",
+              "type": {
+                "text": "boolean | undefined"
+              },
+              "fieldName": "disableSelection"
+            }
+          ],
+          "superclass": {
+            "name": "FRoot",
+            "package": "@cldcvr/flow-core"
+          }
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "FTrow",
+          "declaration": {
+            "name": "FTrow",
+            "module": "src/components/f-trow/f-trow.ts"
           }
         }
       ]
@@ -928,166 +1094,6 @@
           "declaration": {
             "name": "FTcell",
             "module": "src/components/f-tcell/f-tcell.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/f-trow/f-trow.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "",
-          "name": "FTrow",
-          "members": [
-            {
-              "kind": "field",
-              "name": "state",
-              "type": {
-                "text": "FTrowState | undefined"
-              },
-              "default": "\"default\"",
-              "attribute": "state",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "open",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "attribute": "open",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "selected",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "attribute": "selected",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "expandIconPosition",
-              "type": {
-                "text": "FTrowChevronPosition | undefined"
-              },
-              "default": "\"right\"",
-              "attribute": "expand-icon-position",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "disableSelection",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "attribute": "disable-selection",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "expndablePanel",
-              "type": {
-                "text": "FTcell | undefined"
-              }
-            },
-            {
-              "kind": "field",
-              "name": "detailsSlotElement",
-              "type": {
-                "text": "HTMLSlotElement"
-              }
-            },
-            {
-              "kind": "method",
-              "name": "propogateProps",
-              "description": "propogate props related to chevron and checkbox and radio boxes"
-            },
-            {
-              "kind": "method",
-              "name": "toggleDetails",
-              "parameters": [
-                {
-                  "name": "event",
-                  "type": {
-                    "text": "CustomEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handleInput",
-              "parameters": [
-                {
-                  "name": "event",
-                  "type": {
-                    "text": "CustomEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "handleDetailsSlot"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "state",
-              "type": {
-                "text": "FTrowState | undefined"
-              },
-              "default": "\"default\"",
-              "fieldName": "state"
-            },
-            {
-              "name": "open",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "fieldName": "open"
-            },
-            {
-              "name": "selected",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "fieldName": "selected"
-            },
-            {
-              "name": "expand-icon-position",
-              "type": {
-                "text": "FTrowChevronPosition | undefined"
-              },
-              "default": "\"right\"",
-              "fieldName": "expandIconPosition"
-            },
-            {
-              "name": "disable-selection",
-              "type": {
-                "text": "boolean | undefined"
-              },
-              "fieldName": "disableSelection"
-            }
-          ],
-          "superclass": {
-            "name": "FRoot",
-            "package": "@cldcvr/flow-core"
-          }
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "FTrow",
-          "declaration": {
-            "name": "FTrow",
-            "module": "src/components/f-trow/f-trow.ts"
           }
         }
       ]

--- a/packages/flow-table/package.json
+++ b/packages/flow-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-table",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Table component for flow library",
   "module": "dist/flow-table.es.js",
   "main": "dist/flow-table.cjs.js",

--- a/packages/flow-table/src/components/f-table-schema/__snapshots__/f-table-schema.test.snap.js
+++ b/packages/flow-table/src/components/f-table-schema/__snapshots__/f-table-schema.test.snap.js
@@ -393,83 +393,65 @@ snapshots["f-table-schema should display rows and column based on data"] =
         </f-text>
       </f-tcell>
       <f-tcell part="cell">
-        <f-text
-          align="left"
-          size="medium"
-          state="default"
-          style="height:100%"
-          variant="para"
-          weight="regular"
+        <f-div
+          align="top-left"
+          direction="row"
+          gap="small"
+          height="fill-container"
+          overflow="wrap"
+          padding="none"
+          selected="none"
+          state="transparent"
+          sticky="none"
+          style="padding: 0px; border-radius: 0px;"
+          variant="block"
+          width="hug-content"
         >
-          <f-div
-            align="top-left"
-            direction="row"
-            gap="small"
-            height="fill-container"
-            overflow="wrap"
-            padding="none"
-            selected="none"
-            state="transparent"
-            sticky="none"
-            style="padding: 0px; border-radius: 0px;"
-            variant="block"
-            width="hug-content"
+          <f-icon source="i-date-time">
+          </f-icon>
+          <f-text
+            align="left"
+            inline=""
+            size="medium"
+            state="default"
+            variant="para"
+            weight="regular"
           >
-            <f-icon source="i-date-time">
-            </f-icon>
-            <f-text
-              align="left"
-              inline=""
-              size="medium"
-              state="default"
-              variant="para"
-              weight="regular"
-            >
-              17-11-1995
-            </f-text>
-          </f-div>
-        </f-text>
+            17-11-1995
+          </f-text>
+        </f-div>
       </f-tcell>
       <f-tcell part="cell">
-        <f-text
-          align="left"
-          size="medium"
-          state="default"
-          style="height:100%"
-          variant="para"
-          weight="regular"
+        <f-div
+          align="top-left"
+          direction="row"
+          gap="x-small"
+          height="fill-container"
+          overflow="wrap"
+          padding="none"
+          selected="none"
+          state="transparent"
+          sticky="none"
+          style="padding: 0px; border-radius: 0px;"
+          variant="block"
+          width="fill-container"
         >
-          <f-div
-            align="top-left"
-            direction="row"
-            gap="x-small"
-            height="fill-container"
-            overflow="wrap"
-            padding="none"
-            selected="none"
-            state="transparent"
-            sticky="none"
-            style="padding: 0px; border-radius: 0px;"
-            variant="block"
-            width="fill-container"
+          <f-icon
+            source="i-hashtag"
+            state="warning"
           >
-            <f-icon
-              source="i-hashtag"
-              state="warning"
-            >
-            </f-icon>
-            <f-text
-              align="left"
-              inline=""
-              size="medium"
-              state="warning"
-              variant="para"
-              weight="regular"
-            >
-              vikas0@cldcvr.com
-            </f-text>
-          </f-div>
-        </f-text>
+          </f-icon>
+          <f-text
+            align="left"
+            inline=""
+            size="medium"
+            state="warning"
+            variant="para"
+            weight="regular"
+          >
+            vikas0@cldcvr.com
+          </f-text>
+        </f-div>
       </f-tcell>
       <f-tcell part="cell">
         <f-text
@@ -599,83 +581,65 @@ snapshots["f-table-schema should display rows and column based on data"] =
         </f-text>
       </f-tcell>
       <f-tcell part="cell">
-        <f-text
-          align="left"
-          size="medium"
-          state="default"
-          style="height:100%"
-          variant="para"
-          weight="regular"
+        <f-div
+          align="top-left"
+          direction="row"
+          gap="small"
+          height="fill-container"
+          overflow="wrap"
+          padding="none"
+          selected="none"
+          state="transparent"
+          sticky="none"
+          style="padding: 0px; border-radius: 0px;"
+          variant="block"
+          width="hug-content"
         >
-          <f-div
-            align="top-left"
-            direction="row"
-            gap="small"
-            height="fill-container"
-            overflow="wrap"
-            padding="none"
-            selected="none"
-            state="transparent"
-            sticky="none"
-            style="padding: 0px; border-radius: 0px;"
-            variant="block"
-            width="hug-content"
+          <f-icon source="i-date-time">
+          </f-icon>
+          <f-text
+            align="left"
+            inline=""
+            size="medium"
+            state="default"
+            variant="para"
+            weight="regular"
           >
-            <f-icon source="i-date-time">
-            </f-icon>
-            <f-text
-              align="left"
-              inline=""
-              size="medium"
-              state="default"
-              variant="para"
-              weight="regular"
-            >
-              17-11-1995
-            </f-text>
-          </f-div>
-        </f-text>
+            17-11-1995
+          </f-text>
+        </f-div>
       </f-tcell>
       <f-tcell part="cell">
-        <f-text
-          align="left"
-          size="medium"
-          state="default"
-          style="height:100%"
-          variant="para"
-          weight="regular"
+        <f-div
+          align="top-left"
+          direction="row"
+          gap="x-small"
+          height="fill-container"
+          overflow="wrap"
+          padding="none"
+          selected="none"
+          state="transparent"
+          sticky="none"
+          style="padding: 0px; border-radius: 0px;"
+          variant="block"
+          width="fill-container"
         >
-          <f-div
-            align="top-left"
-            direction="row"
-            gap="x-small"
-            height="fill-container"
-            overflow="wrap"
-            padding="none"
-            selected="none"
-            state="transparent"
-            sticky="none"
-            style="padding: 0px; border-radius: 0px;"
-            variant="block"
-            width="fill-container"
+          <f-icon
+            source="i-hashtag"
+            state="warning"
           >
-            <f-icon
-              source="i-hashtag"
-              state="warning"
-            >
-            </f-icon>
-            <f-text
-              align="left"
-              inline=""
-              size="medium"
-              state="warning"
-              variant="para"
-              weight="regular"
-            >
-              vikas1@cldcvr.com
-            </f-text>
-          </f-div>
-        </f-text>
+          </f-icon>
+          <f-text
+            align="left"
+            inline=""
+            size="medium"
+            state="warning"
+            variant="para"
+            weight="regular"
+          >
+            vikas1@cldcvr.com
+          </f-text>
+        </f-div>
       </f-tcell>
       <f-tcell part="cell">
         <f-text

--- a/packages/flow-table/src/components/f-table-schema/f-table-schema.ts
+++ b/packages/flow-table/src/components/f-table-schema/f-table-schema.ts
@@ -28,7 +28,7 @@ export type FTableSchemaData = {
 export type FTableSchemaCell<T = any> = {
 	value: T;
 	actions?: FTcellActions;
-	template?: () => HTMLTemplateResult;
+	template?: (highlightText?: string | null) => HTMLTemplateResult;
 	toString?: () => string;
 };
 
@@ -245,10 +245,8 @@ export class FTableSchema extends FRoot {
 							.width=${width}
 							.actions=${actions}
 							?sticky-left=${ifDefined(sticky)}
-							><f-text style="height:100%" .highlight=${highlightTerm}
-								>${this.getCellTemplate(row.data[columnHeader[0]])}</f-text
-							></f-tcell
-						>`;
+							>${this.getCellTemplate(row.data[columnHeader[0]], highlightTerm)}
+						</f-tcell>`;
 					})}
 				</f-trow>`;
 			}
@@ -504,12 +502,12 @@ export class FTableSchema extends FRoot {
 		this.dispatchEvent(rowInputEvent);
 	}
 
-	getCellTemplate(cell: FTableSchemaCell) {
+	getCellTemplate(cell: FTableSchemaCell, highlightTerm: string | null) {
 		if (cell?.template) {
-			return cell.template();
+			return cell.template(highlightTerm);
 		}
 
-		return cell.value;
+		return html`<f-text style="height:100%" .highlight=${highlightTerm}>${cell.value}</f-text>`;
 	}
 
 	handleColumnSelection(e: CustomEvent) {

--- a/packages/flow-table/src/components/f-tcell/f-tcell.scss
+++ b/packages/flow-table/src/components/f-tcell/f-tcell.scss
@@ -53,5 +53,6 @@ f-tcell {
 		align-items: flex-start;
 		gap: 12px;
 		flex-wrap: wrap;
+		width: 100%;
 	}
 }

--- a/stories/f-popover.stories.mdx
+++ b/stories/f-popover.stories.mdx
@@ -382,36 +382,57 @@ popover and if the max height is attained, the body contents will scroll.
 		{args => {
 			const [dummySizeArray, setDummySizeArray] = useState([
 				{
-					popoverId: "stretchSize",
+					target: "#stretchSize",
 					open: false,
-					title: "Stretch Size",
-					size: "stretch"
+					title: `size="stretch"`,
+					size: "stretch",
+					placement: "auto"
 				},
-				{ popoverId: "large", open: false, title: "Large Size", size: "large" },
+				{ target: "#large", open: false, title: `size="large"`, size: "large", placement: "auto" },
 				{
-					popoverId: "medium",
+					target: "#medium",
 					open: false,
-					title: "Medium Size",
-					size: "medium"
+					title: `size="medium"`,
+					size: "medium",
+					placement: "auto"
 				},
-				{ popoverId: "small", open: false, title: "Small Size", size: "small" }
+				{ target: "#small", open: false, title: `size="medium"`, size: "small", placement: "auto" },
+				{
+					target: undefined,
+					open: false,
+					title: `size="custom(500px,100vh)" placement="right" target="undefined"`,
+					size: "custom(500px,100vh)",
+					placement: "right"
+				}
 			]);
 			const handlePopover = (item, index) => {
 				const array = [...dummySizeArray];
 				array[index].open = !dummySizeArray[index].open;
 				setDummySizeArray(array);
 			};
-			return html` <f-div height="hug-content" gap="large">
+			return html` <f-div height="hug-content" direction="column" gap="large">
 				${dummySizeArray.map((item, index) => {
 					return html`
 						<f-popover
 							?open=${item.open}
-							?overlay=${true}
+							.overlay=${false}
 							size=${item.size}
-							target=${`#${item.popoverId}`}
+							.target=${item.target}
+							placement=${item.placement}
 							@overlay-click=${() => handlePopover(item, index)}
 						>
-							<f-div state="tertiary" padding="medium">
+							<f-div
+								state="tertiary"
+								gap="auto"
+								direction="column"
+								align="bottom-left"
+								padding="medium"
+							>
+								<f-text>
+									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet enim
+									ut mi egestas, non efficitur odio varius. Phasellus accumsan pellentesque ex
+									vehicula tristique.
+								</f-text>
 								<f-text>
 									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus imperdiet enim
 									ut mi egestas, non efficitur odio varius. Phasellus accumsan pellentesque ex
@@ -419,12 +440,17 @@ popover and if the max height is attained, the body contents will scroll.
 								</f-text>
 							</f-div>
 						</f-popover>
-						<f-button
-							id=${item.popoverId}
-							label=${item.title}
+						<f-div
+							id=${item.target?.substring(1)}
+							state="primary"
+							padding="large"
+							variant="curved"
+							width="hug-content"
+							clickable
 							@click=${() => handlePopover(item, index)}
 						>
-						</f-button>
+							<f-text size="large">${item.title}</f-text>
+						</f-div>
 					`;
 				})}
 			</f-div>`;

--- a/stories/utils/mock-users-data.ts
+++ b/stories/utils/mock-users-data.ts
@@ -16,7 +16,14 @@ export default function getFakeUsers(rowCount = 100, columnCount = 8): FTableSch
 
 	for (let i = 0; i < rowCount; i++) {
 		const firstName = { value: faker.name.firstName() };
-		const lastName = { value: faker.name.lastName() };
+		const lastName = {
+			value: faker.name.lastName(),
+			template: function () {
+				return html`<f-div gap="x-small" align="middle-center" width="100%" height="100%"
+					><f-text inline state="success">${this.value}</f-text></f-div
+				>`;
+			}
+		};
 		const email: FTableSchemaCell & { value: string } = {
 			value: faker.internet.email(),
 			template: function () {


### PR DESCRIPTION
# @cldcvr/flow-core

## [1.25.0] - 2023-09-14

### Features

- `f-popover` size property now supports custom size .Ex `size="custom(500px,100vh)"`
- `f-popover` can open without target with custom placements. Ex. `size="custom(500px,100vh)" placement="right"` this will open popover on extreme right like slideout.
### Bug Fixes
- `f-popover` : `@overlay-click` not emitted when `:overlay="false"`

# @cldcvr/flow-table

## [1.3.2] - 2023-09-13

### Bug Fixes

- `f-table-schema` : cell with template not taking full width.