### PR TITLE
FLOW-939 | f-pictogram adding category prop

### DIFF
--- a/packages/flow-code-editor/CHANGELOG.md
+++ b/packages/flow-code-editor/CHANGELOG.md
@@ -1,33 +1,37 @@
 <h4 className="margin-btm-8">Release Notes</h4>
 
-## 1.0.3
+
+# Change Log
+
+## [1.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
-  - @cldcvr/flow-core@2.0.3
+- `@cldcvr/flow-core-config@1.1.3`
+- `@cldcvr/flow-core@2.0.3`
 
-## 1.0.2
+
+## [1.0.2] - 2023-10-10
 
 ### Patch Changes
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
-  - @cldcvr/flow-core@2.0.1
+- `@cldcvr/flow-core-config@1.1.1`
+- `@cldcvr/flow-core@2.0.1`
 
-## 1.0.1-beta.0
+## [1.0.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
-  - @cldcvr/flow-core@2.0.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
+- `@cldcvr/flow-core@2.0.1-beta.0`
 
-## 1.0.0
+## [1.0.0] - 2023-10-10
 
 ### Minor Changes
 
@@ -36,10 +40,9 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core@2.0.0
-  <hr className="margin-btm-32" />
+- `@cldcvr/flow-core@2.0.0`
+<hr className="margin-btm-32" />
 
-# Change Log
 
 ## [0.2.0] - 2023-08-03
 

--- a/packages/flow-core-config/CHANGELOG.md
+++ b/packages/flow-core-config/CHANGELOG.md
@@ -1,31 +1,32 @@
 <h4 class="margin-btm-8">Release Notes</h4>
 
-## 1.1.3
+
+# Change Log
+
+## [1.1.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 
-## 1.1.2
+## [1.1.2] - 2023-10-10
 
 ### Patch Changes
 
-- a2de106: Fix platform types
+- `a2de106`: Fix platform types
 
-## 1.1.1-beta.0
+## [1.1.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 
-## 1.1.0
+## [1.1.0] - 2023-10-10
 
 ### Minor Changes
 
 - Migrated to monorepo structure and removed the need for custom CSS
 <hr class="margin-btm-32" />
-
-# Change Log
 
 ## [1.0.0] - 2023-06-21
 

--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -1,30 +1,40 @@
 <h4 className="margin-btm-8">Release Notes</h4>
 
-## 2.0.3
+
+# Change Log
+
+## [2.0.4] - 2023-10-13
+
+### Improvements
+
+- `f-pictogram`: added `category` prop having two types `fill` and `outline`.
+
+## [2.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
+- `@cldcvr/flow-core-config@1.1.3`
 
-## 2.0.2
+
+## [2.0.2] - 2023-10-10 
 
 ### Patch Changes
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
+- @cldcvr/flow-core-config@1.1.1
 
-## 2.0.1-beta.0
+## [2.0.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
 
-## 2.0.0
+## [2.0.0] - 2023-10-10
 
 ### Major Changes
 
@@ -33,11 +43,10 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.0
-  <hr className="margin-btm-32" />
-  <p className="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
+- `@cldcvr/flow-core-config@1.1.0`
+<hr className="margin-btm-32" />
+<p className="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
 
-# Change Log
 
 ## [1.26.4] - 2023-10-06
 

--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -24,7 +24,7 @@
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-- @cldcvr/flow-core-config@1.1.1
+- `@cldcvr/flow-core-config@1.1.1`
 
 ## [2.0.1-beta.0] - 2023-10-10
 
@@ -47,6 +47,7 @@
 <hr className="margin-btm-32" />
 <p className="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
 
+# Change Log
 
 ## [1.26.4] - 2023-10-06
 

--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -47,7 +47,6 @@
 <hr className="margin-btm-32" />
 <p className="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
 
-# Change Log
 
 ## [1.26.4] - 2023-10-06
 

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-pictogram/f-pictogram.scss
+++ b/packages/flow-core/src/components/f-pictogram/f-pictogram.scss
@@ -1,4 +1,5 @@
 @use "sass:map";
+@use "sass:math";
 @import "./../../mixins/scss/mixins";
 
 $sizes: (
@@ -30,22 +31,28 @@ $sizes: (
 
 $states: (
 	"primary": (
-		"background": var(--color-primary-default)
+		"background": var(--color-primary-default),
+		"text": var(--color-primary-text)
 	),
 	"default": (
-		"background": var(--color-neutral-subtle)
+		"background": var(--color-neutral-subtle),
+		"text": var(--color-text-default)
 	),
 	"success": (
-		"background": var(--color-success-default)
+		"background": var(--color-success-default),
+		"text": var(--color-success-text)
 	),
 	"warning": (
-		"background": var(--color-warning-default)
+		"background": var(--color-warning-default),
+		"text": var(--color-warning-text)
 	),
 	"danger": (
-		"background": var(--color-danger-default)
+		"background": var(--color-danger-default),
+		"text": var(--color-danger-text)
 	),
 	"inherit": (
-		"background": var(--color-inherit-pictogram)
+		"background": var(--color-inherit-pictogram),
+		"text": var(--color-text-default)
 	)
 );
 
@@ -138,8 +145,34 @@ $hexagon-clip-path: polygon(
 
 :host {
 	.f-pictogram {
-		--after-background-color: var(--color-neutral-subtle);
-		--after-background-color-hover: var(--color-neutral-subtle-hover);
+		&[category="fill"] {
+			@each $state, $color in $states {
+				&[state="default"] {
+					--after-background-color: var(--color-neutral-subtle);
+					--after-background-color-hover: var(--color-neutral-subtle-hover);
+				}
+				&[state="success"] {
+					--after-background-color: var(--color-success-surface);
+					--after-background-color-hover: var(--color-success-surface-hover);
+				}
+				&[state="primary"] {
+					--after-background-color: var(--color-primary-surface);
+					--after-background-color-hover: var(--color-primary-surface-hover);
+				}
+				&[state="danger"] {
+					--after-background-color: var(--color-danger-surface);
+					--after-background-color-hover: var(--color-danger-surface-hover);
+				}
+				&[state="warning"] {
+					--after-background-color: var(--color-warning-surface);
+					--after-background-color-hover: var(--color-warning-surface-hover);
+				}
+			}
+		}
+		&[category="outline"] {
+			--after-background-color: var(--color-neutral-subtle);
+			--after-background-color-hover: var(--color-neutral-subtle-hover);
+		}
 
 		display: inline-flex;
 		justify-content: center;
@@ -179,7 +212,11 @@ $hexagon-clip-path: polygon(
 					font-style: normal;
 					font-weight: 400;
 					line-height: 18px;
-					color: var(--color-text-default);
+					@each $state, $color in $states {
+						&[state="#{$state}"] {
+							color: map-get($color, "text");
+						}
+					}
 				}
 			}
 		}

--- a/packages/flow-core/src/components/f-pictogram/f-pictogram.ts
+++ b/packages/flow-core/src/components/f-pictogram/f-pictogram.ts
@@ -52,7 +52,7 @@ export class FPictogram extends FRoot {
 	/**
 	 * css loaded from scss file
 	 */
-	static styles = [unsafeCSS(eleStyle), ...FIcon.styles];
+	static styles = [unsafeCSS(eleStyle), unsafeCSS(globalStyle), ...FIcon.styles];
 
 	/**
 	 * @attribute Variants are various representations of Pictogram. For example Pictogram can be round, curved, square, or hexagon.

--- a/packages/flow-core/src/components/f-pictogram/f-pictogram.ts
+++ b/packages/flow-core/src/components/f-pictogram/f-pictogram.ts
@@ -310,9 +310,7 @@ export class FPictogram extends FRoot {
 			</div>
 		`;
 	}
-	protected async updated(
-		changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>
-	): Promise<void> {
+	protected updated(changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
 		super.updated(changedProperties);
 		if (this.fPicorgramWrapper && this.autoBg && this.isText) {
 			// Modify the background-color property

--- a/packages/flow-core/src/components/f-pictogram/f-pictogram.ts
+++ b/packages/flow-core/src/components/f-pictogram/f-pictogram.ts
@@ -1,4 +1,4 @@
-import { html, PropertyValueMap, unsafeCSS } from "lit";
+import { html, unsafeCSS } from "lit";
 import { property, query } from "lit/decorators.js";
 import eleStyle from "./f-pictogram.scss?inline";
 import globalStyle from "./f-pictogram-global.scss?inline";
@@ -167,45 +167,6 @@ export class FPictogram extends FRoot {
 		return "";
 	}
 
-	get statesBasedBackground() {
-		const defaultColor = {
-			background: "var(color-neutral-sublte)",
-			hover: "var(color-neutral-sublte-hover)"
-		};
-		if (this.state) {
-			const mapper = {
-				default: {
-					background: "var(color-neutral-sublte)",
-					hover: "var(color-neutral-sublte-hover)"
-				},
-				primary: {
-					background: "var(color-primary-surface)",
-					hover: "var(color-primary-surface-hover)"
-				},
-				danger: {
-					background: "var(color-danger-surface)",
-					hover: "var(color-danger-surface-hover)"
-				},
-				success: {
-					background: "var(color-success-surface)",
-					hover: "var(color-success-surface-hover)"
-				},
-				warning: {
-					background: "var(color-warning-surface)",
-					hover: "var(color-warning-surface-hover)"
-				},
-				inherit: {
-					background: "var(color-neutral-sublte)",
-					hover: "var(color-neutral-sublte-hover)"
-				}
-			};
-
-			return this.category === "fill" ? mapper[this.state] ?? defaultColor : defaultColor;
-		} else {
-			return defaultColor;
-		}
-	}
-
 	// returns html where source is being as input
 	get renderedHtml() {
 		const emojiRegex = /\p{Extended_Pictographic}/u;
@@ -267,6 +228,15 @@ export class FPictogram extends FRoot {
 		return this.stringReplaceAtIndex(color, color.length - 2, 0.7);
 	}
 
+	applyStyles() {
+		if (this.fPicorgramWrapper && this.autoBg && this.isText) {
+			// Modify the background-color property
+			return `--after-background-color: ${this.hashCode}; --after-background-color-hover: ${this.hashCodeHover}; --before-background-color:${this.hashCode}`;
+		} else {
+			return ``;
+		}
+	}
+
 	validateProperties() {
 		if (!this.source) {
 			throw new Error("f-pictogram : source is mandatory field");
@@ -294,6 +264,7 @@ export class FPictogram extends FRoot {
 				?loading=${this.loading}
 				?clickable=${this.clickable}
 				?auto-bg=${this.autoBg}
+				style=${this.applyStyles()}
 			>
 				${unsafeHTML(this.renderedHtml)}
 				${this.variant === "squircle"
@@ -309,28 +280,6 @@ export class FPictogram extends FRoot {
 					: null}
 			</div>
 		`;
-	}
-	protected updated(changedProperties: PropertyValueMap<any> | Map<PropertyKey, unknown>): void {
-		super.updated(changedProperties);
-		if (this.fPicorgramWrapper && this.autoBg && this.isText) {
-			// Modify the background-color property
-			this.fPicorgramWrapper.style.setProperty("--after-background-color", this.hashCode);
-			this.fPicorgramWrapper.style.setProperty(
-				"--after-background-color-hover",
-				this.hashCodeHover
-			);
-			this.fPicorgramWrapper.style.setProperty("--before-background-color", this.hashCode);
-		} else {
-			this.fPicorgramWrapper.style.setProperty(
-				"--after-background-color",
-				this.statesBasedBackground?.background
-			);
-			this.fPicorgramWrapper.style.setProperty(
-				"--after-background-color-hover",
-				this.statesBasedBackground?.hover
-			);
-			this.fPicorgramWrapper.style.setProperty("--before-background-color", "");
-		}
 	}
 }
 

--- a/packages/flow-form-builder/CHANGELOG.md
+++ b/packages/flow-form-builder/CHANGELOG.md
@@ -1,33 +1,37 @@
 <h4 class="margin-btm-8">Release Notes</h4>
 
-## 2.0.3
+
+# Change Log
+
+## [2.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
-  - @cldcvr/flow-core@2.0.3
+- `@cldcvr/flow-core-config@1.1.3`
+- `@cldcvr/flow-core@2.0.3`
 
-## 2.0.2
+
+## [2.0.2] - 2023-10-10
 
 ### Patch Changes
 
-- a2de106: Fix platform types
+- `a2de106`: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
-  - @cldcvr/flow-core@2.0.1
+- `@cldcvr/flow-core-config@1.1.1`
+- `@cldcvr/flow-core@2.0.1`
 
-## 2.0.1-beta.0
+## [2.0.1-beta.0] -2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
-  - @cldcvr/flow-core@2.0.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
+- `@cldcvr/flow-core@2.0.1-beta.0`
 
-## 2.0.0
+## [2.0.0] - 2023-10-10
 
 ### Major Changes
 
@@ -36,11 +40,9 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core@2.0.0
-  <hr class="margin-btm-32" />
-  <p class="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
-
-# Change Log
+- `@cldcvr/flow-core@2.0.0`
+<hr class="margin-btm-32" />
+<p class="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
 
 ## [1.7.8] - 2023-09-08
 

--- a/packages/flow-lineage/CHANGELOG.md
+++ b/packages/flow-lineage/CHANGELOG.md
@@ -1,6 +1,5 @@
 <h4 class="margin-btm-8">Release Notes</h4>
 
-
 # Change Log
 
 ## [3.0.3] - 2023-10-12
@@ -42,7 +41,6 @@
 - `@cldcvr/flow-core@2.0.0`
 <hr class="margin-btm-32" />
 <p class="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
-
 
 ## [2.0.1] - 2023-09-11
 

--- a/packages/flow-lineage/CHANGELOG.md
+++ b/packages/flow-lineage/CHANGELOG.md
@@ -1,33 +1,36 @@
 <h4 class="margin-btm-8">Release Notes</h4>
 
-## 3.0.3
+
+# Change Log
+
+## [3.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
-  - @cldcvr/flow-core@2.0.3
+- `@cldcvr/flow-core-config@1.1.3`
+- `@cldcvr/flow-core@2.0.3`
 
-## 3.0.2
+## [3.0.2] - 2023-10-10
 
 ### Patch Changes
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
-  - @cldcvr/flow-core@2.0.1
+- `@cldcvr/flow-core-config@1.1.1`
+- `@cldcvr/flow-core@2.0.1`
 
-## 3.0.1-beta.0
+## [3.0.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
-  - @cldcvr/flow-core@2.0.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
+- `@cldcvr/flow-core@2.0.1-beta.0`
 
-## 3.0.0
+## [3.0.0] - 2023-10-10
 
 ### Major Changes
 
@@ -36,11 +39,10 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core@2.0.0
-  <hr class="margin-btm-32" />
-  <p class="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
+- `@cldcvr/flow-core@2.0.0`
+<hr class="margin-btm-32" />
+<p class="margin-btm-24">All notable changes to this project will be documented in this file. See <a>Conventional Commits</a> for commit guidelines. </p>
 
-# Change Log
 
 ## [2.0.1] - 2023-09-11
 

--- a/packages/flow-log/CHANGELOG.md
+++ b/packages/flow-log/CHANGELOG.md
@@ -1,33 +1,37 @@
 <h4 className="margin-btm-8">Release Notes</h4>
 
-## 1.0.3
+
+
+# Change Log
+
+## [1.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
-  - @cldcvr/flow-core@2.0.3
+- `@cldcvr/flow-core-config@1.1.3`
+- `@cldcvr/flow-core@2.0.3`
 
-## 1.0.2
+## [1.0.2] - 2023-10-10
 
 ### Patch Changes
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
-  - @cldcvr/flow-core@2.0.1
+- `@cldcvr/flow-core-config@1.1.1`
+- `@cldcvr/flow-core@2.0.1`
 
-## 1.0.1-beta.0
+## [1.0.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
-  - @cldcvr/flow-core@2.0.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
+- `@cldcvr/flow-core@2.0.1-beta.0`
 
-## 1.0.0
+## [1.0.0] - 2023-10-10
 
 ### Minor Changes
 
@@ -36,10 +40,8 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core@2.0.0
-  <hr className="margin-btm-32" />
-
-# Change Log
+- `@cldcvr/flow-core@2.0.0`
+<hr className="margin-btm-32" />
 
 ## [0.0.1] - 2023-05-29
 

--- a/packages/flow-md-editor/CHANGELOG.md
+++ b/packages/flow-md-editor/CHANGELOG.md
@@ -1,33 +1,36 @@
 <h4 className="margin-btm-8">Release Notes</h4>
 
-## 2.0.3
+
+# Change Log
+
+## [2.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
-  - @cldcvr/flow-core@2.0.3
+- `@cldcvr/flow-core-config@1.1.3`
+- `@cldcvr/flow-core@2.0.3`
 
-## 2.0.2
+## [2.0.2] - 2023-10-10
 
 ### Patch Changes
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
-  - @cldcvr/flow-core@2.0.1
+- `@cldcvr/flow-core-config@1.1.1`
+- `@cldcvr/flow-core@2.0.1`
 
-## 2.0.1-beta.0
+## [2.0.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
-  - @cldcvr/flow-core@2.0.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
+- `@cldcvr/flow-core@2.0.1-beta.0`
 
-## 2.0.0
+## [2.0.0] - 2023-10-10
 
 ### Major Changes
 
@@ -36,10 +39,8 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core@2.0.0
-  <hr className="margin-btm-32" />
-
-# Change Log
+- `@cldcvr/flow-core@2.0.0`
+<hr className="margin-btm-32" />
 
 ## [1.0.0] - 2023-07-20
 

--- a/packages/flow-table/CHANGELOG.md
+++ b/packages/flow-table/CHANGELOG.md
@@ -1,33 +1,36 @@
 <h4 className="margin-btm-8">Release Notes</h4>
 
-## 2.0.3
+
+# Change Log
+
+## [2.0.3] - 2023-10-12
 
 ### Patch Changes
 
 - Remove sideEffects because the components require registration via import
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.3
-  - @cldcvr/flow-core@2.0.3
+- `@cldcvr/flow-core-config@1.1.3`
+- `@cldcvr/flow-core@2.0.3`
 
-## 2.0.2
+## [2.0.2] - 2023-10-10
 
 ### Patch Changes
 
 - a2de106: Fix platform types
 - Updated dependencies [a2de106]
-  - @cldcvr/flow-core-config@1.1.1
-  - @cldcvr/flow-core@2.0.1
+- `@cldcvr/flow-core-config@1.1.1`
+- `@cldcvr/flow-core@2.0.1`
 
-## 2.0.1-beta.0
+## [2.0.1-beta.0] - 2023-10-10
 
 ### Patch Changes
 
 - Fix platform types
 - Updated dependencies
-  - @cldcvr/flow-core-config@1.1.1-beta.0
-  - @cldcvr/flow-core@2.0.1-beta.0
+- `@cldcvr/flow-core-config@1.1.1-beta.0`
+- `@cldcvr/flow-core@2.0.1-beta.0`
 
-## 2.0.0
+## [2.0.0] - 2023-10-10
 
 ### Major Changes
 
@@ -36,10 +39,8 @@
 ### Patch Changes
 
 - Updated dependencies
-  - @cldcvr/flow-core@2.0.0
-  <hr className="margin-btm-32" />
-
-# Change Log
+- `@cldcvr/flow-core@2.0.0`
+<hr className="margin-btm-32" />
 
 ## [1.3.4] - 2023-10-05
 

--- a/stories/flow-core/f-pictogram.mdx
+++ b/stories/flow-core/f-pictogram.mdx
@@ -22,7 +22,7 @@ content.
 
 <br />
 
-### [Playground](/story/components-f-pictogram--playground)
+### [Playground](?path=/story/cldcvr-flow-core-f-pictogram--playground)
 
 <Canvas>
 	<Story of={FPictogramStories.Playground} />
@@ -92,6 +92,44 @@ square or squircle.
 </table>
 
 <br />
+
+## category
+
+<f-divider />
+
+Category is of two types: fill & outline
+
+<Canvas>
+	<Story of={FPictogramStories.Category} />
+</Canvas>
+
+<table className="custom-table">
+  <tbody>
+    <tr>
+      <td>Value</td>
+      <td>Description</td>
+
+      <td />
+    </tr>
+
+    <tr>
+      <td>fill</td>
+      <td>fills the background with state colors</td>
+
+      <td>
+        <code>default</code>
+      </td>
+    </tr>
+
+    <tr>
+      <td>square</td>
+      <td>border of the pictogram takes the state colors</td>
+
+      <td />
+    </tr>
+
+  </tbody>
+</table>
 
 ## source
 

--- a/stories/flow-core/f-pictogram.stories.js
+++ b/stories/flow-core/f-pictogram.stories.js
@@ -24,6 +24,7 @@ export const Playground = {
 				.disabled=${args.disabled}
 				.clickable=${args.clickable}
 				?auto-bg=${args["auto-bg"]}
+				.category=${args.category}
 			></f-pictogram>
 		</f-div>`,
 
@@ -33,6 +34,11 @@ export const Playground = {
 		variant: {
 			control: "select",
 			options: ["squircle", "sqaure", "circle", "hexagon"]
+		},
+
+		category: {
+			control: "radio",
+			options: ["fill", "outline"]
 		},
 
 		size: {
@@ -87,6 +93,7 @@ export const Playground = {
 
 	args: {
 		variant: "squircle",
+		category: "fill",
 		source: "i-app",
 		size: "medium",
 		state: "default",

--- a/stories/flow-core/f-pictogram.stories.js
+++ b/stories/flow-core/f-pictogram.stories.js
@@ -164,6 +164,46 @@ export const Variant = {
 	}
 };
 
+export const Category = {
+	render: args =>
+		html`<f-div gap="medium" padding="x-large" direction="row" align="middle-center">
+			<f-div
+				height="hug-content"
+				align="middle-center"
+				padding="none"
+				gap="large"
+				direction="column"
+			>
+				<f-text variant="para" size="large" weight="medium">outline</f-text>
+				<f-pictogram
+					source="i-tick"
+					size="x-large"
+					state="success"
+					category="outline"
+				></f-pictogram>
+			</f-div>
+			<f-div
+				height="hug-content"
+				align="middle-center"
+				padding="none"
+				gap="large"
+				direction="column"
+			>
+				<f-text variant="para" size="large" weight="medium">fill</f-text>
+				<f-pictogram source="i-tick" size="x-large" state="success" category="fill"></f-pictogram>
+			</f-div>
+		</f-div>`,
+
+	name: "category",
+
+	parameters: {
+		docs: {
+			inlineStories: false,
+			iframeHeight: 200
+		}
+	}
+};
+
 export const Source = {
 	render: args =>
 		html`<f-div gap="medium" padding="x-large" direction="row" align="middle-center">

--- a/stories/flow-core/f-pictogram.stories.ts
+++ b/stories/flow-core/f-pictogram.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit-html";
 import fPictogramAnatomy from "../svg/i-fpictogram-anatomy.js";
 import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
+import { FPictogramVariant, FPictogramCategory, FPictogramSize, FPictogramState } from "@cldcvr/flow-core";
 
 export default {
 	title: "@cldcvr/flow-core/f-pictogram",
@@ -12,8 +13,21 @@ export default {
 	}
 };
 
+
+export type PictogramArgs = {
+	source:string,
+	variant: FPictogramVariant,
+	category: FPictogramCategory,
+	size: FPictogramSize,
+	state: FPictogramState,
+	'auto-bg': boolean,
+	disabled:boolean,
+	clickable: boolean,
+	loading:boolean,
+}
+
 export const Playground = {
-	render: args =>
+	render: (args:PictogramArgs) =>
 		html`<f-div direction="column" padding="x-large">
 			<f-pictogram
 				.variant=${args.variant}
@@ -110,7 +124,7 @@ export const Anatomy = {
 };
 
 export const Variant = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="x-large" direction="row" align="middle-center">
 			<f-div
 				height="hug-content"
@@ -165,7 +179,7 @@ export const Variant = {
 };
 
 export const Category = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="x-large" direction="row" align="middle-center">
 			<f-div
 				height="hug-content"
@@ -205,7 +219,7 @@ export const Category = {
 };
 
 export const Source = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="medium" padding="x-large" direction="row" align="middle-center">
 			<f-div padding="large" gap="medium" direction="column" width="hug-content">
 				<f-div height="hug-content" padding="none" align="middle-center">
@@ -254,7 +268,7 @@ export const Source = {
 };
 
 export const Size = {
-	render: args => html`<f-div gap="medium" padding="x-large" align="middle-center">
+	render: () => html`<f-div gap="medium" padding="x-large" align="middle-center">
       <f-div padding="large" gap="medium" direction="column" width="hug-content">
         <f-div height="hug-content" padding="none" align="middle-center">
           <f-text variant="para" size="large" weight="medium">x-large</f-text>
@@ -300,7 +314,7 @@ export const Size = {
 };
 
 export const State = {
-	render: args => html`<f-div gap="medium" padding="x-large" align="middle-center">
+	render: () => html`<f-div gap="medium" padding="x-large" align="middle-center">
       <f-div padding="large" gap="medium" direction="column" width="hug-content">
         <f-div height="hug-content" padding="none" align="middle-center">
           <f-text variant="para" size="large" weight="medium">default</f-text>
@@ -354,27 +368,27 @@ export const State = {
 };
 
 export const Flags = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" direction="column">
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Loading</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large" overflow="hidden">
 				<f-pictogram source="💬" size="x-large"></f-pictogram>
-				<f-pictogram source="💬" size="x-large" loading=${true}></f-pictogram>
+				<f-pictogram source="💬" size="x-large" ?loading=${true}></f-pictogram>
 			</f-div>
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Disabled</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
 				<f-pictogram source="💬" size="x-large"></f-pictogram>
-				<f-pictogram source="💬" size="x-large" disabled=${true}></f-pictogram>
+				<f-pictogram source="💬" size="x-large" ?disabled=${true}></f-pictogram>
 			</f-div>
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">Clickable</f-text>
 			</f-div>
 			<f-div padding="none" direction="row" gap="x-large">
-				<f-pictogram source="💬" size="x-large" clickable=${true}></f-pictogram>
+				<f-pictogram source="💬" size="x-large" ?clickable=${true}></f-pictogram>
 			</f-div>
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">auto-bg</f-text>


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR
- `f-pictogram`: added `category` prop having two types `fill` and `outline`.
<img width="1093" alt="Screenshot 2023-10-11 at 6 30 15 PM" src="https://github.com/cldcvr/flow-core/assets/23555670/b42e57c8-8741-4c74-a5a5-34ad282711d6">


### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
