### PR TITLE
feat(ui): FLOW-941 | f-breadcrumbs variant prop introduced

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.1.0] - 2023-10-16
+
+### Features
+
+- `f-breadcrumb`: added `variant` property which includes `text` and `icon` to display breadcrumbs in two different variants.
+
 ## [2.0.5] - 2023-10-16
 
 ### Bug fixes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.scss
+++ b/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.scss
@@ -1,6 +1,78 @@
 @import "./../../mixins/scss/mixins";
 
 :host {
+	.f-breadcrumbs {
+		gap: 2px !important;
+		.f-breadcrumb {
+			border-radius: 2px !important;
+		}
+		.f-breadcrumb-primary {
+			display: flex;
+			background-color: var(--color-primary-default);
+			position: relative;
+
+			justify-content: center;
+			align-items: center;
+			border-radius: 2px;
+
+			&[size="medium"] {
+				width: 27px;
+				height: 32px;
+				&::after {
+					position: absolute;
+					right: -10px;
+					content: "";
+					width: 0px;
+					height: 0px;
+					border-top: 15px solid transparent;
+					border-bottom: 15px solid transparent;
+					border-left: 10px solid var(--color-primary-default);
+				}
+
+				.f-breadcrumb-primary-icon {
+					position: absolute;
+					top: 8px;
+					left: 7px;
+				}
+
+				&:hover {
+					background-color: var(--color-primary-default-hover);
+					cursor: pointer;
+					&::after {
+						border-left: 10px solid var(--color-primary-default-hover);
+					}
+				}
+			}
+			&[size="small"] {
+				width: 25px;
+				height: 28px;
+				&::after {
+					position: absolute;
+					right: -8px;
+					content: "";
+					width: 0px;
+					height: 0px;
+					border-top: 13px solid transparent;
+					border-bottom: 13px solid transparent;
+					border-left: 8px solid var(--color-primary-default);
+				}
+
+				&:hover {
+					background-color: var(--color-primary-default-hover);
+					cursor: pointer;
+					&::after {
+						border-left: 8px solid var(--color-primary-default-hover);
+					}
+				}
+
+				.f-breadcrumb-primary-icon {
+					position: absolute;
+					top: 8px;
+					left: 8px;
+				}
+			}
+		}
+	}
 	.f-breadcrumb-content {
 		max-width: 100px !important;
 		.f-breadcrumb-text-hover {

--- a/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.test.ts
+++ b/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.test.ts
@@ -88,18 +88,18 @@ describe("f-breadcrumb", () => {
 	it("should render with icon variant and the last crumb should be in active primary mode", async () => {
 		const el = await fixture(html`
 			<f-breadcrumb 
-			.variant=${"icon"} 
+			variant="icon"
 			.crumbs=${[
-					{ tabIndex: 0, title: "Label 1", icon:"i-app" },
-					{ tabIndex: 1, title: "Label 2", icon:"i-app" },
-					{ tabIndex: 2, title: "Label 3", icon: "i-home" },
-					{ tabIndex: 3, title: "Label 4", icon:"i-info-fill" },
+					{ tabIndex: 0, title: "Home", icon:"i-app" },
+					{ tabIndex: 1, title: "New Label", icon:"i-app" },
+					{ tabIndex: 2, title: "Pipeline", icon: "i-home" },
+					{ tabIndex: 3, title: "Working", icon:"i-info-fill" },
 					{ tabIndex: 4, title: "Active", icon:"i-app" }
 				]}
 			></f-breadcrumb>
 		`);
-		const descendant = el.shadowRoot!.querySelector(".f-breadcrumbs")!;
-		const selected = descendant.children[descendant.children.length-1];
+		const descendants = el.shadowRoot!.querySelector(".f-breadcrumbs")!;
+		const selected = descendants.children[descendants.children.length-1];
 		const text = selected.querySelector("f-text")!
 		expect(text.innerHTML).includes("Active");
 	});

--- a/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.test.ts
+++ b/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.test.ts
@@ -24,6 +24,7 @@ describe("f-breadcrumb", () => {
 			></f-breadcrumb>
 		`);
 		expect(el.getAttribute("size")).to.equal("medium");
+		expect(el.getAttribute("variant")).to.equal("text");
 	});
 	it("should render with x-small text-size when size is small", async () => {
 		const el = await fixture(html`
@@ -65,5 +66,41 @@ describe("f-breadcrumb", () => {
 		`);
 		const descendant = el.shadowRoot!.querySelectorAll(".popover-crumb-list")!;
 		expect(descendant.length).to.equal(2);
+	});
+
+	it("should render with icon variant crumbs", async () => {
+		const el = await fixture(html`
+			<f-breadcrumb 
+			.variant=${"icon"} 
+			.crumbs=${[
+					{ tabIndex: 0, title: "Label 1", icon:"i-app" },
+					{ tabIndex: 1, title: "Label 2", icon:"i-app" },
+					{ tabIndex: 2, title: "Label 3", icon: "i-home" },
+					{ tabIndex: 3, title: "Label 4", icon:"i-info-fill" },
+					{ tabIndex: 4, title: "Label 5", icon:"i-app" }
+				]}
+			></f-breadcrumb>
+		`);
+		const descendant = el.shadowRoot!.querySelector(".f-breadcrumbs")!;
+		expect(descendant.children.length).to.equal(5);
+	});
+
+	it("should render with icon variant and the last crumb should be in active primary mode", async () => {
+		const el = await fixture(html`
+			<f-breadcrumb 
+			.variant=${"icon"} 
+			.crumbs=${[
+					{ tabIndex: 0, title: "Label 1", icon:"i-app" },
+					{ tabIndex: 1, title: "Label 2", icon:"i-app" },
+					{ tabIndex: 2, title: "Label 3", icon: "i-home" },
+					{ tabIndex: 3, title: "Label 4", icon:"i-info-fill" },
+					{ tabIndex: 4, title: "Active", icon:"i-app" }
+				]}
+			></f-breadcrumb>
+		`);
+		const descendant = el.shadowRoot!.querySelector(".f-breadcrumbs")!;
+		const selected = descendant.children[descendant.children.length-1];
+		const text = selected.querySelector("f-text")!
+		expect(text.innerHTML).includes("Active");
 	});
 });

--- a/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.ts
+++ b/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.ts
@@ -12,7 +12,7 @@ import { injectCss } from "@cldcvr/flow-core-config";
 
 injectCss("f-breadcrumb", globalStyle);
 
-export type FBreadCrumbsProp = { tabIndex: number; title: string };
+export type FBreadCrumbsProp = { tabIndex: number; title: string; icon?: string };
 export type FBreadcrumbs = FBreadCrumbsProp[];
 
 @flowElement("f-breadcrumb")
@@ -33,6 +33,12 @@ export class FBreadcrumb extends FRoot {
 	 */
 	@property({ reflect: true, type: String })
 	size?: "medium" | "small" = "medium";
+
+	/**
+	 * @attribute variant defines the type of brundcrumbs.
+	 */
+	@property({ reflect: true, type: String })
+	variant?: "text" | "icon" = "text";
 
 	/**
 	 * @attribute The medium size is the default.
@@ -64,6 +70,14 @@ export class FBreadcrumb extends FRoot {
 	 */
 	get textSize() {
 		return this.size === "medium" ? "small" : "x-small";
+	}
+
+	get iconSize() {
+		return this.size === "medium" ? "small" : "x-small";
+	}
+
+	get crumbSize() {
+		return this.size === "medium" ? "32px" : "28px";
 	}
 
 	/**
@@ -146,87 +160,132 @@ export class FBreadcrumb extends FRoot {
 			bubbles: true,
 			composed: true
 		});
-		this.popOverElement.open = false;
+		if (this.variant === "text") {
+			this.popOverElement.open = false;
+		}
 		this.dispatchEvent(event);
 	}
 
 	render() {
 		this.createSeperateCrumbs();
-		return html` <f-div gap="x-small" align="middle-left">
-			${this.crumbs?.length <= 4
-				? this.crumbs?.map((crumb, index) => this.crumbLoop(crumb, index, this.crumbs))
-				: html`
-						<f-div
-							width="hug-content"
-							align="middle-left"
-							class="f-breadcrumb-content"
-							?disabled=${this.disabled}
-							@click=${(event: MouseEvent) => this.handleDispatchEvent(event, this.initialCrumbs)}
-						>
-							<f-text
-								.size=${this.textSize}
-								variant="para"
-								weight="regular"
-								class="f-breadcrumb-text-hover"
-								.tooltip=${this.initialCrumbs?.title}
-								?ellipsis=${true}
-								>${this.initialCrumbs?.title}</f-text
-							>
-						</f-div>
-						<f-icon
-							source="i-chevron-right"
-							size="x-small"
-							state="secondary"
-							class="system-icon-size"
-						></f-icon>
-						<f-div
-							clickable
-							?disabled=${this.disabled}
-							@mouseenter=${() => this.toggleBreadcrumbPopover("open")}
-							id="breadcrumb-popover"
-						>
-							<f-text class="toggle-popover-hover" variant="heading" state="secondary" size="small"
-								>...</f-text
-							>
-						</f-div>
-						<f-popover .overlay=${false} size="small">
-							<f-div
-								state="secondary"
-								direction="column"
-								@mouseleave=${() => this.toggleBreadcrumbPopover("close")}
-							>
-								${this.middlePopoverCrumbs?.map(
-									(crumb, index) =>
-										html` <f-div
-											class="popover-crumb-list"
-											padding="medium"
-											.border=${this.middlePopoverCrumbs.length - 1 === index
-												? "none"
-												: "small solid secondary bottom"}
-											clickable
-											@click=${(event: MouseEvent) => this.handleDispatchEvent(event, crumb)}
-											><f-text
-												class="popover-text-hover"
-												variant="para"
-												size="medium"
-												weight="regular"
-												>${crumb?.title}</f-text
-											></f-div
-										>`
+		return this.variant === "text"
+			? html` <f-div gap="x-small" align="middle-left">
+					${this.crumbs?.length <= 4
+						? this.crumbs?.map((crumb, index) => this.crumbLoop(crumb, index, this.crumbs))
+						: html`
+								<f-div
+									width="hug-content"
+									align="middle-left"
+									class="f-breadcrumb-content"
+									?disabled=${this.disabled}
+									@click=${(event: MouseEvent) =>
+										this.handleDispatchEvent(event, this.initialCrumbs)}
+								>
+									<f-text
+										.size=${this.textSize}
+										variant="para"
+										weight="regular"
+										class="f-breadcrumb-text-hover"
+										.tooltip=${this.initialCrumbs?.title}
+										?ellipsis=${true}
+										>${this.initialCrumbs?.title}</f-text
+									>
+								</f-div>
+								<f-icon
+									source="i-chevron-right"
+									size="x-small"
+									state="secondary"
+									class="system-icon-size"
+								></f-icon>
+								<f-div
+									clickable
+									?disabled=${this.disabled}
+									@mouseenter=${() => this.toggleBreadcrumbPopover("open")}
+									id="breadcrumb-popover"
+								>
+									<f-text
+										class="toggle-popover-hover"
+										variant="heading"
+										state="secondary"
+										size="small"
+										>...</f-text
+									>
+								</f-div>
+								<f-popover .overlay=${false} size="small">
+									<f-div
+										state="secondary"
+										direction="column"
+										@mouseleave=${() => this.toggleBreadcrumbPopover("close")}
+									>
+										${this.middlePopoverCrumbs?.map(
+											(crumb, index) =>
+												html` <f-div
+													class="popover-crumb-list"
+													padding="medium"
+													.border=${this.middlePopoverCrumbs.length - 1 === index
+														? "none"
+														: "small solid secondary bottom"}
+													clickable
+													@click=${(event: MouseEvent) => this.handleDispatchEvent(event, crumb)}
+													><f-text
+														class="popover-text-hover"
+														variant="para"
+														size="medium"
+														weight="regular"
+														>${crumb?.title}</f-text
+													></f-div
+												>`
+										)}
+									</f-div>
+								</f-popover>
+								<f-icon
+									source="i-chevron-right"
+									size="x-small"
+									state="secondary"
+									class="system-icon-size"
+								></f-icon>
+								${this.endingCrumbs?.map((crumb, index) =>
+									this.crumbLoop(crumb, index, this.endingCrumbs)
 								)}
-							</f-div>
-						</f-popover>
-						<f-icon
-							source="i-chevron-right"
-							size="x-small"
-							state="secondary"
-							class="system-icon-size"
-						></f-icon>
-						${this.endingCrumbs?.map((crumb, index) =>
-							this.crumbLoop(crumb, index, this.endingCrumbs)
-						)}
-				  `}
-		</f-div>`;
+						  `}
+			  </f-div>`
+			: html`<f-div class="f-breadcrumbs" overflow="visible">
+					${this.crumbs.map((item, index) =>
+						index !== this.crumbs.length - 1
+							? html`<f-div
+									class="f-breadcrumb"
+									state="secondary"
+									width=${this.crumbSize}
+									height=${this.crumbSize}
+									padding="small"
+									align="middle-center"
+									variant="curved"
+									tooltip=${item.title}
+									clickable
+									@click=${(event: MouseEvent) => this.handleDispatchEvent(event, item)}
+							  >
+									<f-icon source=${item.icon} .size=${this.iconSize}></f-icon>
+							  </f-div>`
+							: html`
+									<f-div gap="large" align="middle-center">
+										<div
+											class="f-breadcrumb-primary"
+											size=${this.size}
+											@click=${(event: MouseEvent) => this.handleDispatchEvent(event, item)}
+										>
+											<f-icon
+												source=${item.icon}
+												.size=${this.iconSize}
+												class="f-breadcrumb-primary-icon"
+											></f-icon>
+										</div>
+										<f-text inline variant="para" .size=${this.textSize} weight="medium">
+											${item.title}</f-text
+										>
+									</f-div>
+							  `
+					)}
+			  </f-div>`;
 	}
 }
 

--- a/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.ts
+++ b/packages/flow-core/src/components/f-breadcrumb/f-breadcrumb.ts
@@ -12,8 +12,14 @@ import { injectCss } from "@cldcvr/flow-core-config";
 
 injectCss("f-breadcrumb", globalStyle);
 
+const variants = ["text", "icon"] as const;
+const sizes = ["medium", "small"] as const;
+ 
 export type FBreadCrumbsProp = { tabIndex: number; title: string; icon?: string };
 export type FBreadcrumbs = FBreadCrumbsProp[];
+export type FBreadcrumbSize = (typeof sizes)[number];
+export type FBreadcrumbVariant = (typeof variants)[number];
+
 
 @flowElement("f-breadcrumb")
 export class FBreadcrumb extends FRoot {
@@ -32,13 +38,13 @@ export class FBreadcrumb extends FRoot {
 	 * @attribute The medium size is the default.
 	 */
 	@property({ reflect: true, type: String })
-	size?: "medium" | "small" = "medium";
+	size?: FBreadcrumbSize = "medium";
 
 	/**
 	 * @attribute variant defines the type of brundcrumbs.
 	 */
 	@property({ reflect: true, type: String })
-	variant?: "text" | "icon" = "text";
+	variant?: FBreadcrumbVariant = "text";
 
 	/**
 	 * @attribute The medium size is the default.
@@ -168,8 +174,9 @@ export class FBreadcrumb extends FRoot {
 
 	render() {
 		this.createSeperateCrumbs();
-		return this.variant === "text"
-			? html` <f-div gap="x-small" align="middle-left">
+
+
+		const textBreadcrumb = html` <f-div gap="x-small" align="middle-left">
 					${this.crumbs?.length <= 4
 						? this.crumbs?.map((crumb, index) => this.crumbLoop(crumb, index, this.crumbs))
 						: html`
@@ -249,7 +256,8 @@ export class FBreadcrumb extends FRoot {
 								)}
 						  `}
 			  </f-div>`
-			: html`<f-div class="f-breadcrumbs" overflow="visible">
+
+			  const iconBreadcrumb = html`<f-div class="f-breadcrumbs" overflow="visible">
 					${this.crumbs.map((item, index) =>
 						index !== this.crumbs.length - 1
 							? html`<f-div
@@ -285,7 +293,10 @@ export class FBreadcrumb extends FRoot {
 									</f-div>
 							  `
 					)}
-			  </f-div>`;
+			  </f-div>`
+		return this.variant === "text"
+			? textBreadcrumb
+			: iconBreadcrumb;
 	}
 }
 

--- a/stories/flow-core/f-breadcrumb.mdx
+++ b/stories/flow-core/f-breadcrumb.mdx
@@ -84,6 +84,21 @@ Crumbs property represents the array of crumbs in a breadcrumb.
 
 <br />
 
+
+### variant
+
+<f-divider />
+
+variant consists of two types, text and icon.
+
+<br />
+
+<Canvas>
+	<Story of={FBreadcrumbStories.Variant} />
+</Canvas>
+
+<br />
+
 ## Flags
 
 <f-divider />

--- a/stories/flow-core/f-breadcrumb.stories.js
+++ b/stories/flow-core/f-breadcrumb.stories.js
@@ -21,6 +21,7 @@ export const Playground = {
 		return html` <f-div padding="small">
 			<f-breadcrumb
 				.crumbs=${args.crumbs}
+				.variant=${args.variant}
 				.size=${args.size}
 				?disabled=${args.disabled}
 				@click=${handleClick}
@@ -36,6 +37,11 @@ export const Playground = {
 			options: ["medium", "small"]
 		},
 
+		variant: {
+			control: "radio",
+			options: ["text", "icon"]
+		},
+
 		crumbs: {
 			control: "object"
 		},
@@ -47,27 +53,32 @@ export const Playground = {
 
 	args: {
 		size: "medium",
-
+		variant: "text",
 		crumbs: [
 			{
 				tabIndex: 0,
-				title: "Label 1 New Label Demo test"
+				title: "Label 1 New Label Demo test",
+				icon: "i-home"
 			},
 			{
 				tabIndex: 1,
-				title: "Label 2"
+				title: "Label 2",
+				icon: "i-pipe"
 			},
 			{
 				tabIndex: 2,
-				title: "Label 3"
+				title: "Label 3",
+				icon: "i-info-fill"
 			},
 			{
 				tabIndex: 3,
-				title: "Label 4"
+				title: "Label 4",
+				icon: "i-app"
 			},
 			{
 				tabIndex: 4,
-				title: "Label 5"
+				title: "Label 5",
+				icon: "i-download"
 			}
 		],
 

--- a/stories/flow-core/f-breadcrumb.stories.ts
+++ b/stories/flow-core/f-breadcrumb.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit-html";
 import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
-import { useArgs, useState } from "@storybook/client-api";
+import { useArgs } from "@storybook/manager-api";
+import { useState } from "@storybook/preview-api";
 import { FBreadcrumbs, FBreadCrumbSize, FBreadCrumbVariant } from "@cldcvr/flow-core";
 
 export default {

--- a/stories/flow-core/f-breadcrumb.stories.ts
+++ b/stories/flow-core/f-breadcrumb.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "lit-html";
 import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
 import { useArgs, useState } from "@storybook/client-api";
+import { FBreadcrumbs, FBreadCrumbSize, FBreadCrumbVariant } from "@cldcvr/flow-core";
 
 export default {
 	title: "@cldcvr/flow-core/f-breadcrumb",
@@ -12,9 +13,16 @@ export default {
 	}
 };
 
+export type BreadcrumbArgTypes = {
+	crumbs: FBreadcrumbs,
+	size: FBreadCrumbSize,
+	variant: FBreadCrumbVariant,
+	disabled: boolean
+}
+
 export const Playground = {
-	render: args => {
-		const handleClick = e => {
+	render: (args:BreadcrumbArgTypes) => {
+		const handleClick = (e:CustomEvent) => {
 			console.log(e.detail.value);
 		};
 
@@ -87,8 +95,12 @@ export const Playground = {
 };
 
 export const Size = {
-	render: args => {
-		const data = ["medium", "small"];
+	render: () => {
+
+		type dataString = "medium" | "small"
+		type dataType = dataString[]
+		const data = ["medium", "small"] as dataType;
+
 
 		const crumbs = [
 			{
@@ -124,7 +136,7 @@ export const Size = {
 };
 
 export const Crumbs = {
-	render: args => {
+	render: () => {
 		const data = [
 			[
 				{
@@ -182,8 +194,79 @@ export const Crumbs = {
 	name: "crumbs"
 };
 
+
+
+export const Variant = {
+	render: () => {
+		const data = [
+			[
+				{
+					tabIndex: 0,
+					title: "Home",
+				},
+				{
+					tabIndex: 1,
+					title: "Label 2",
+				},
+				{
+					tabIndex: 2,
+					title: "Label 3",
+				},
+				{
+					tabIndex: 3,
+					title: "Label 4",
+				},
+				{
+					tabIndex: 4,
+					title: "Current",
+				}
+			],
+			[
+				{
+					tabIndex: 0,
+					title: "Home",
+					icon: "i-home"
+				},
+				{
+					tabIndex: 1,
+					title: "Label 2",
+					icon:"i-app"
+				},
+				{
+					tabIndex: 2,
+					title: "Label 3",
+					icon:"i-launch"
+				},
+				{
+					tabIndex: 3,
+					title: "info",
+					icon: "i-info-fill"
+				},
+				{
+					tabIndex: 4,
+					title: "Current",
+					icon:"i-user-double"
+				}
+			]
+		];
+
+		return html`<f-div padding="small" gap="x-large">
+			${data.map(
+				(item, index) =>
+					html` <f-div direction="column" gap="large"
+						><f-text>${index===0 ? "variant='text'" : "variant='icon'"}</f-text
+						><f-breadcrumb .crumbs=${item} .variant=${index===0?'text':'icon'}></f-breadcrumb
+					></f-div>`
+			)}
+		</f-div>`;
+	},
+
+	name: "variant"
+};
+
+
 export const Flags = {
-	render: args => {
+	render: () => {
 		const crumbs = [
 			{
 				tabIndex: 0,


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR
- `f-breadcrumb`: added `variant` property which includes `text` and `icon` to display breadcrumbs in two different variants.

<img width="1006" alt="Screenshot 2023-10-13 at 3 32 08 PM" src="https://github.com/cldcvr/flow-core/assets/23555670/89afd010-87f3-463f-86e8-bb3f37efa220">


### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
