### PR TITLE
Issue-157 | FLOW-946 | Disabling option in actions FTcellActions array in every row of f-table-schema

### DIFF
--- a/packages/flow-table/CHANGELOG.md
+++ b/packages/flow-table/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 # Change Log
 
+## [2.0.4] - 2023-10-16
+
+### Improvements
+
+- `disabled` added for f-table-cell actions.
+
 ## [2.0.3] - 2023-10-12
 
 ### Patch Changes

--- a/packages/flow-table/package.json
+++ b/packages/flow-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-table",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Table component for flow library",
   "module": "dist/flow-table.es.js",
   "main": "dist/flow-table.cjs.js",

--- a/packages/flow-table/src/components/f-tcell/f-tcell.ts
+++ b/packages/flow-table/src/components/f-tcell/f-tcell.ts
@@ -14,6 +14,7 @@ export type FTcellAction = {
 	icon: string;
 	id: string;
 	tooltip?: string;
+	disabled?: boolean;
 	onClick?: (event: PointerEvent, element?: FIconButton) => void;
 	onMouseOver?: (event: MouseEvent, element?: FIconButton) => void;
 	onMouseLeave?: (event: MouseEvent, element?: FIconButton) => void;
@@ -80,6 +81,7 @@ export class FTcell extends FRoot {
 					size="medium"
 					category="packed"
 					state="neutral"
+					?disabled=${ac.disabled}
 					.icon=${ac.icon}
 					.tooltip=${ac.tooltip ?? undefined}
 					@click=${(event: PointerEvent) => {


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR
- `disabled` added for f-table-cell actions.

### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
