### PR TITLE
issue-170 tooltip type updated to accept as object

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 # Change Log
 
+## [2.1.3] - 2023-10-18
+
+### Improvements
+
+- `tooltip` property now accepts object
+
+```
+{
+    text: string;
+    closable?: boolean;
+    placement?: FTooltipPlacement;
+}
+```
+
 ## [2.1.2] - 2023-10-18
 
 ### Bug Fixes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/mixins/components/f-root/f-root.ts
+++ b/packages/flow-core/src/mixins/components/f-root/f-root.ts
@@ -21,6 +21,8 @@ export type FTooltipObject = {
 	placement?: FTooltipPlacement;
 };
 
+export type FRootTooltip = string | FTooltipObject;
+
 /**
  * @summary Every component must extent this class to consume gbobal styles , such as css reset, font family,...
  *
@@ -35,7 +37,7 @@ export class FRoot extends LitElement {
 	 * @attribute Value of a switch defines if it is on or off.
 	 */
 	@property({ reflect: true, type: String })
-	tooltip?: string | FTooltipObject;
+	tooltip?: FRootTooltip;
 
 	get tooltipText() {
 		if (typeof this.tooltip === "object") {

--- a/packages/flow-core/src/mixins/components/f-root/f-root.ts
+++ b/packages/flow-core/src/mixins/components/f-root/f-root.ts
@@ -3,15 +3,23 @@ import { property, query } from "lit/decorators.js";
 
 import globalStyle from "./f-root-global.scss?inline";
 import { injectCss } from "@cldcvr/flow-core-config";
+import { FTooltipPlacement } from "../../../components/f-tooltip/f-tooltip";
 
 // to avoid recursive tye check
 type TooltipElement = HTMLElement & {
 	target: unknown;
 	open: boolean;
 	closable: boolean;
+	placement?: FTooltipPlacement;
 };
 
 injectCss("f-root", globalStyle);
+
+export type FTooltipObject = {
+	text: string;
+	closable?: boolean;
+	placement?: FTooltipPlacement;
+};
 
 /**
  * @summary Every component must extent this class to consume gbobal styles , such as css reset, font family,...
@@ -27,7 +35,14 @@ export class FRoot extends LitElement {
 	 * @attribute Value of a switch defines if it is on or off.
 	 */
 	@property({ reflect: true, type: String })
-	tooltip?: string;
+	tooltip?: string | FTooltipObject;
+
+	get tooltipText() {
+		if (typeof this.tooltip === "object") {
+			return this.tooltip.text;
+		}
+		return this.tooltip;
+	}
 
 	mouseEnter?: () => void;
 
@@ -101,8 +116,17 @@ export class FRoot extends LitElement {
 					if (!isExternalTooltip) {
 						const tooltipText = tooltipElement?.querySelector("#tooltip-text");
 						if (tooltipText) {
-							tooltipText.innerHTML = this.tooltip as string;
+							tooltipText.innerHTML = this.tooltipText as string;
 						}
+					}
+
+					if (typeof this.tooltip === "object") {
+						tooltipElement.closable = this.tooltip.closable ?? false;
+						tooltipElement.placement = this.tooltip.placement ?? "auto";
+					} else {
+						//reset to original
+						tooltipElement.closable = false;
+						tooltipElement.placement = "auto";
 					}
 					tooltipElement.open = true;
 				}
@@ -121,15 +145,15 @@ export class FRoot extends LitElement {
 			/**
 			 * If tooltip is specified by user
 			 */
-			if (this.tooltip) {
+			if (this.tooltipText) {
 				/**
 				 * check if tooltip contains id
 				 */
-				if (this.tooltip.startsWith("#")) {
-					tooltipElement = document.querySelector<TooltipElement>(this.tooltip);
+				if (this.tooltipText.startsWith("#")) {
+					tooltipElement = document.querySelector<TooltipElement>(this.tooltipText);
 					isExternalTooltip = true;
 					if (!tooltipElement) {
-						console.warn(`${this.tooltip} tooltip not found`);
+						console.warn(`${this.tooltipText} tooltip not found`);
 					}
 				}
 				/**

--- a/packages/flow-core/src/mixins/components/f-root/f-root.ts
+++ b/packages/flow-core/src/mixins/components/f-root/f-root.ts
@@ -40,7 +40,7 @@ export class FRoot extends LitElement {
 	tooltip?: FRootTooltip;
 
 	get tooltipText() {
-		if (typeof this.tooltip === "object") {
+		if (this.tooltip !== null && typeof this.tooltip === "object") {
 			return this.tooltip.text;
 		}
 		return this.tooltip;
@@ -122,7 +122,7 @@ export class FRoot extends LitElement {
 						}
 					}
 
-					if (typeof this.tooltip === "object") {
+					if (this.tooltip !== null && typeof this.tooltip === "object") {
 						tooltipElement.closable = this.tooltip.closable ?? false;
 						tooltipElement.placement = this.tooltip.placement ?? "auto";
 					} else {

--- a/packages/flow-form-builder/CHANGELOG.md
+++ b/packages/flow-form-builder/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # Change Log
 
+## [2.0.5] - 2023-10-18
+
+### Patch Changes
+
+- `iconTooltip` type changed.
+- `min-value` and `max-value` default messages updated.
+
 ## [2.0.4] - 2023-10-16
 
 ### Patch Changes

--- a/packages/flow-form-builder/package.json
+++ b/packages/flow-form-builder/package.json
@@ -42,7 +42,7 @@
     "web-component-analyzer": "^2.0.0-next.4"
   },
   "peerDependencies": {
-    "@cldcvr/flow-core": "^2.0.3",
+    "@cldcvr/flow-core": "^2.1.3",
     "@cldcvr/flow-core-config": "^1.1.3"
   },
   "repository": {

--- a/packages/flow-form-builder/package.json
+++ b/packages/flow-form-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-form-builder",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Form builder for the flow design system",
   "module": "dist/flow-form-builder.es.js",
   "main": "dist/flow-form-builder.cjs.js",

--- a/packages/flow-form-builder/src/modules/validation/default-validation-messages/index.ts
+++ b/packages/flow-form-builder/src/modules/validation/default-validation-messages/index.ts
@@ -4,8 +4,8 @@ const messages: Record<string, string> = {
 	between: "{{name}} must be between {{min}} and {{max}}",
 	min: "{{name}} must be at least {{length}} characters long",
 	max: "{{name}} can be max {{length}} characters long",
-	["min-value"]: "{{name}} must be greater than {{min}}",
-	["max-value"]: "{{name}} must be less than {{max}}",
+	["min-value"]: "{{name}} must be greater than or equal to {{min}}",
+	["max-value"]: "{{name}} must be less than or equal to {{max}}",
 	regex: "{{name}} is not matching with {{regex}}"
 };
 

--- a/packages/flow-form-builder/src/types.ts
+++ b/packages/flow-form-builder/src/types.ts
@@ -19,7 +19,7 @@ import {
 	FDateTimePickerState,
 	FDateOption,
 	DateDisableType,
-	FTooltipObject
+	FRootTooltip
 } from "@cldcvr/flow-core";
 import { BetweenParams } from "./modules/validation/rules/between";
 import { Subject } from "rxjs";
@@ -243,8 +243,7 @@ export type CheckboxOption = {
 	qaId?: string;
 	title?: string | HTMLTemplateResult;
 	description?: string;
-	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-	iconTooltip?: string | FTooltipObject;
+	iconTooltip?: FRootTooltip;
 	subTitle?: string;
 	disabled?: boolean;
 };
@@ -277,8 +276,7 @@ export type FormBuilderSuffixCondition = (value: string) => boolean;
 export type FormBuilderLabel = {
 	title: string | HTMLTemplateResult; // title of field/group/form
 	description?: string; // more info about title (displayed at bottom of label)
-	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-	iconTooltip?: string | FTooltipObject; //icon to display besides title
+	iconTooltip?: FRootTooltip; //icon to display besides title
 	subTitle?: string | HTMLTemplateResult;
 };
 

--- a/packages/flow-form-builder/src/types.ts
+++ b/packages/flow-form-builder/src/types.ts
@@ -18,7 +18,8 @@ import {
 	FSelectOptionTemplate,
 	FDateTimePickerState,
 	FDateOption,
-	DateDisableType
+	DateDisableType,
+	FTooltipObject
 } from "@cldcvr/flow-core";
 import { BetweenParams } from "./modules/validation/rules/between";
 import { Subject } from "rxjs";
@@ -242,7 +243,8 @@ export type CheckboxOption = {
 	qaId?: string;
 	title?: string | HTMLTemplateResult;
 	description?: string;
-	iconTooltip?: string;
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+	iconTooltip?: string | FTooltipObject;
 	subTitle?: string;
 	disabled?: boolean;
 };
@@ -275,7 +277,8 @@ export type FormBuilderSuffixCondition = (value: string) => boolean;
 export type FormBuilderLabel = {
 	title: string | HTMLTemplateResult; // title of field/group/form
 	description?: string; // more info about title (displayed at bottom of label)
-	iconTooltip?: string; //icon to display besides title
+	// eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+	iconTooltip?: string | FTooltipObject; //icon to display besides title
 	subTitle?: string | HTMLTemplateResult;
 };
 

--- a/stories/flow-core/f-tooltip.stories.ts
+++ b/stories/flow-core/f-tooltip.stories.ts
@@ -1,7 +1,7 @@
 import { html } from "lit-html";
-import { unsafeSVG } from "lit-html/directives/unsafe-svg.js";
 import { unsafeHTML } from "lit-html/directives/unsafe-html.js";
-import { useArgs, useState } from "@storybook/client-api";
+import { useState } from "@storybook/preview-api";
+import { FTooltipObject, FTooltipPlacement } from "@cldcvr/flow-core";
 
 export default {
 	title: "@cldcvr/flow-core/f-tooltip",
@@ -13,8 +13,16 @@ export default {
 	}
 };
 
+type TooltipStoryArgs = {
+	tooltip: string | FTooltipObject;
+	closable: boolean;
+	open: boolean;
+	placement: FTooltipPlacement;
+	["Custom Tooltip Template"]: string;
+};
+
 export const PlaygroundDirectiveTooltip = {
-	render: args =>
+	render: (args: TooltipStoryArgs) =>
 		html`<f-div padding="large" height="200px" align="middle-center" gap="auto">
 			<f-icon source="i-question-filled" size="medium" .tooltip=${args.tooltip} clickable></f-icon>
 			<f-button label="Submit" .tooltip=${args.tooltip}></f-button>
@@ -33,13 +41,17 @@ export const PlaygroundDirectiveTooltip = {
 	},
 
 	args: {
-		tooltip: "This is a tooltip!"
+		tooltip: {
+			text: "This is object tooltip",
+			placement: "bottom",
+			closable: true
+		}
 	}
 };
 
 export const PlaygroundRichTooltipComponent = {
-	render: args =>
-		html`${args.tooltip.startsWith("#")
+	render: (args: TooltipStoryArgs) =>
+		html`${typeof args.tooltip === "string" && args.tooltip.startsWith("#")
 			? html`<f-div padding="large" height="200px" align="middle-center" gap="large">
 						<f-icon-button icon="i-plus" .tooltip=${args.tooltip}></f-icon-button>
 						<f-button label="Submit" .tooltip=${args.tooltip}></f-button>
@@ -103,7 +115,7 @@ export const PlaygroundRichTooltipComponent = {
 };
 
 export const Id = {
-	render: args => {
+	render: () => {
 		return html`
 			<f-div gap="large" padding="x-large" direction="column">
 				<f-div height="hug-content" padding="none">
@@ -142,7 +154,7 @@ export const Id = {
 };
 
 export const Placement = {
-	render: args => {
+	render: () => {
 		const [dummyPlacementArray, setDummyPlacementArray] = useState([
 			[
 				{
@@ -210,10 +222,10 @@ export const Placement = {
 
 		return html`
 			<f-div height="hug-content" gap="large" direction="column">
-				${dummyPlacementArray.map((item, index) => {
+				${dummyPlacementArray.map(item => {
 					return html`
 						<f-div height="hug-content" gap="auto" direction="row">
-							${item.map((main, main_index) => {
+							${item.map(main => {
 								return html`
 									<f-tooltip placement=${main.placement} id=${main.placement}>
 										<f-text variant="para" size="small" id="tooltip-text">
@@ -241,7 +253,7 @@ export const Placement = {
 };
 
 export const Flags = {
-	render: args =>
+	render: () =>
 		html`<f-div gap="large" padding="x-large" direction="column">
 			<f-div height="hug-content" padding="none">
 				<f-text variant="para" size="large" weight="medium">closable="true"</f-text>

--- a/stories/flow-form-builder/f-formbuilder-field.ts
+++ b/stories/flow-form-builder/f-formbuilder-field.ts
@@ -192,7 +192,11 @@ const field: FormBuilderField = {
 			label: {
 				title: html`<f-text state="warning" weight="bold">Radios</f-text>`,
 				subTitle: "Optional",
-				iconTooltip: "Test Radio tooltip"
+				iconTooltip: {
+					text: "Test Radio tooltip",
+					closable: true,
+					placement: "right"
+				}
 			},
 			helperText: html`<f-text size="small" state="subtle">Checking helper text</f-text>`,
 			options: [

--- a/stories/flow-form-builder/f-formbuilder-field.ts
+++ b/stories/flow-form-builder/f-formbuilder-field.ts
@@ -14,7 +14,15 @@ const field: FormBuilderField = {
 	},
 	fields: {
 		number: {
-			type: "number"
+			type: "number",
+			validationRules: [
+				{
+					name: "max-value",
+					params: {
+						max: 5
+					}
+				}
+			]
 		},
 		hiddenField: {
 			type: "hidden",


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [x] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

#### @cldcvr/flow-core

## [2.1.3] - 2023-10-18

### Improvements

- `tooltip` property now accepts object

```
{
    text: string;
    closable?: boolean;
    placement?: FTooltipPlacement;
}
```
---

#### @cldcvr/flow-form-builder

## [2.0.5] - 2023-10-18

### Patch Changes

- `iconTooltip` type changed.
- `min-value` and `max-value` default messages updated.
