### PR TITLE
FLOW-949 | f-accordion: width out of the bounds wrt parent div in a specific case

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.1.5] - 2023-10-19
+
+### Bug Fixes
+
+- `f-accordion`: max-width bug fixed for `f-aacordion` when direction="row"
+
 ## [2.1.4] - 2023-10-18
 
 ### Patch Changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-div/f-div-global.scss
+++ b/packages/flow-core/src/components/f-div/f-div-global.scss
@@ -321,6 +321,9 @@ f-div {
 		> f-div[height="fill-container"] {
 			height: 100%;
 		}
+		> f-accordion{
+			max-width: 100%;
+		}
 	}
 
 	&[direction="row"] {


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR
- `f-accordion`: max-width bug fixed for `f-aacordion` when direction="row"


### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
