### PR TITLE
issue-180 f-tooltip closable attribute not working fixed

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.1.8] - 2023-10-20
+
+### Patch Changes
+
+- `f-tooltip` : `closable="true"` not working
+
 ## [2.1.7] - 2023-10-20
 
 ### Patch Changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/mixins/components/f-root/f-root.ts
+++ b/packages/flow-core/src/mixins/components/f-root/f-root.ts
@@ -125,7 +125,7 @@ export class FRoot extends LitElement {
 					if (this.tooltip !== null && typeof this.tooltip === "object") {
 						tooltipElement.closable = this.tooltip.closable ?? false;
 						tooltipElement.placement = this.tooltip.placement ?? "auto";
-					} else {
+					} else if (!isExternalTooltip) {
 						//reset to original
 						tooltipElement.closable = false;
 						tooltipElement.placement = "auto";


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @cldcvr/flow-core

## [2.1.8] - 2023-10-20

### Patch Changes

- `f-tooltip` : `closable="true"` not working
