### PR TITLE
FLOW-966 | Text Tokens font-weight bug, requires updation from figma

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.3.1] - 2023-11-22
+
+### Features
+
+- font-weights for `<f-text variant="heading"></f-text>` updated in text-tokens received from figma API.
+
 ## [2.3.0] - 2023-11-15
 
 ### Features

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-text/_f-text-variables-dynamic.scss
+++ b/packages/flow-core/src/components/f-text/_f-text-variables-dynamic.scss
@@ -1,15 +1,5 @@
 $variants: (
 	"code": (
-		"large": (
-			"fontSize": var(--text-code-large-font),
-			"lineHeight": var(--text-code-large-lineheight),
-			"weight": (
-				"medium": var(--text-code-large-medium),
-				"bold": var(--text-code-large-bold),
-				"regular": var(--text-code-large-regular)
-			),
-			"fontFamily": var(--text-code-large-fontfamily)
-		),
 		"small": (
 			"fontSize": var(--text-code-small-font),
 			"lineHeight": var(--text-code-small-lineheight),
@@ -19,6 +9,16 @@ $variants: (
 				"regular": var(--text-code-small-regular)
 			),
 			"fontFamily": var(--text-code-small-fontfamily)
+		),
+		"large": (
+			"fontSize": var(--text-code-large-font),
+			"lineHeight": var(--text-code-large-lineheight),
+			"weight": (
+				"medium": var(--text-code-large-medium),
+				"bold": var(--text-code-large-bold),
+				"regular": var(--text-code-large-regular)
+			),
+			"fontFamily": var(--text-code-large-fontfamily)
 		),
 		"medium": (
 			"fontSize": var(--text-code-medium-font),

--- a/packages/flow-core/src/mixins/scss/_text-tokens.scss
+++ b/packages/flow-core/src/mixins/scss/_text-tokens.scss
@@ -163,18 +163,6 @@
 
 [data-theme="f-dark"],
 [data-theme="f-light"] {
-	--text-code-large-font: 16px;
-
-	--text-code-large-lineheight: 26px;
-
-	--text-code-large-medium: 350;
-
-	--text-code-large-bold: 400;
-
-	--text-code-large-regular: 325;
-
-	--text-code-large-fontfamily: "Operator Mono", monospace;
-
 	--text-code-small-font: 12px;
 
 	--text-code-small-lineheight: 18px;
@@ -186,6 +174,18 @@
 	--text-code-small-regular: 325;
 
 	--text-code-small-fontfamily: "Operator Mono", monospace;
+
+	--text-code-large-font: 16px;
+
+	--text-code-large-lineheight: 26px;
+
+	--text-code-large-medium: 350;
+
+	--text-code-large-bold: 400;
+
+	--text-code-large-regular: 325;
+
+	--text-code-large-fontfamily: "Operator Mono", monospace;
 
 	--text-code-medium-font: 14px;
 
@@ -275,9 +275,9 @@
 
 	--text-heading-small-lineheight: 20px;
 
-	--text-heading-small-medium: 350;
+	--text-heading-small-medium: 500;
 
-	--text-heading-small-bold: 400;
+	--text-heading-small-bold: 700;
 
 	--text-heading-small-regular: 400;
 
@@ -287,11 +287,11 @@
 
 	--text-heading-x-large-lineheight: 32px;
 
-	--text-heading-x-large-medium: 350;
+	--text-heading-x-large-medium: 500;
 
 	--text-heading-x-large-bold: 700;
 
-	--text-heading-x-large-regular: 325;
+	--text-heading-x-large-regular: 400;
 
 	--text-heading-x-large-fontfamily: "Montserrat", sans-serif;
 
@@ -299,11 +299,11 @@
 
 	--text-heading-medium-lineheight: 22px;
 
-	--text-heading-medium-medium: 350;
+	--text-heading-medium-medium: 500;
 
 	--text-heading-medium-bold: 700;
 
-	--text-heading-medium-regular: 325;
+	--text-heading-medium-regular: 400;
 
 	--text-heading-medium-fontfamily: "Montserrat", sans-serif;
 
@@ -313,9 +313,9 @@
 
 	--text-heading-large-medium: 500;
 
-	--text-heading-large-bold: 400;
+	--text-heading-large-bold: 700;
 
-	--text-heading-large-regular: 325;
+	--text-heading-large-regular: 400;
 
 	--text-heading-large-fontfamily: "Montserrat", sans-serif;
 


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR
- font-weights for `<f-text variant="heading"></f-text>` updated in text-tokens received from figma API.
<img width="1019" alt="Screenshot 2023-11-22 at 6 55 48 PM" src="https://github.com/cldcvr/flow-core/assets/23555670/27bf5196-bada-488d-bac5-03943754c527">


### Add additional question here

- [ ] `Yes`
- [ ] `No`
- [ ] `NA`
