### PR TITLE
FLOW-967 chevron reference added in f-trow

### DIFF
--- a/packages/flow-table/CHANGELOG.md
+++ b/packages/flow-table/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.0.8] - 2023-11-28
+
+### Improvements
+
+- `f-trow` : `chevron` reference added to trigger click externally using JS.
+
 ## [2.0.7] - 2023-11-20
 
 ### Improvements

--- a/packages/flow-table/package.json
+++ b/packages/flow-table/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-table",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Table component for flow library",
   "module": "dist/flow-table.es.js",
   "main": "dist/flow-table.cjs.js",

--- a/packages/flow-table/src/components/f-trow/f-trow.ts
+++ b/packages/flow-table/src/components/f-trow/f-trow.ts
@@ -1,7 +1,7 @@
 import { html, PropertyValueMap, unsafeCSS } from "lit";
 import { property, query } from "lit/decorators.js";
 
-import { FDiv, FIcon, FRoot, flowElement } from "@cldcvr/flow-core";
+import { FDiv, FIcon, FRoot, flowElement, FIconButton } from "@cldcvr/flow-core";
 import { FTcell } from "../f-tcell/f-tcell";
 import eleStyle from "./f-trow.scss?inline";
 import globalStyle from "./f-trow-global.scss?inline";
@@ -61,6 +61,8 @@ export class FTrow extends FRoot {
 
 	@query("slot[name='details']")
 	detailsSlotElement!: HTMLSlotElement;
+
+	chevron: FIconButton | undefined;
 
 	render() {
 		return html`<slot
@@ -132,12 +134,12 @@ export class FTrow extends FRoot {
 			}
 			chevronCell.expandIcon = true;
 			chevronCell.expandIconPosition = this.expandIconPosition as FTrowChevronPosition;
-			const chevron = chevronCell.chevron;
-			if (chevron) {
+			this.chevron = chevronCell.chevron;
+			if (this.chevron) {
 				if (this.open) {
-					chevron.icon = "i-chevron-up";
+					this.chevron.icon = "i-chevron-up";
 				} else {
-					chevron.icon = "i-chevron-down";
+					this.chevron.icon = "i-chevron-down";
 				}
 			}
 		}


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @cldcvr/flow-table

## [2.0.8] - 2023-11-28

### Improvements

- `f-trow` : `chevron` reference added to trigger click externally using JS.
