### PR TITLE
FLOW-971 f-input typescript issue fixed

### DIFF
--- a/packages/flow-core/CHANGELOG.md
+++ b/packages/flow-core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # Change Log
 
+## [2.6.1] - 2023-12-04
+
+### Bug fixes
+
+- re-exporting types of `f-input-base` from `f-input`. (To fix component type generation bug).
+
 ## [2.6.0] - 2023-12-04
 
 ### Minor Changes

--- a/packages/flow-core/package.json
+++ b/packages/flow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cldcvr/flow-core",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Core package of flow design system",
   "module": "dist/flow-core.es.js",
   "main": "dist/flow-core.cjs.js",

--- a/packages/flow-core/src/components/f-input/f-input.ts
+++ b/packages/flow-core/src/components/f-input/f-input.ts
@@ -11,6 +11,8 @@ import { FInputBase, FInputCustomEvent } from "./f-input-base";
 import { FInputLight } from "./f-input-light";
 injectCss("f-input", globalStyle);
 
+export type { FInputState, FInputCustomEvent, FInputSuffixWhen } from "./f-input-base";
+
 @flowElement("f-input")
 export class FInput extends FInputBase {
 	/**


### PR DESCRIPTION
### Checklist for raising a PR

- [ ] Gone through UX documnetation for adding new features.
- [ ] All necessary unit tests covered.
- [ ] Required comments added for generating component manifest file? you can find details [here](https://custom-elements-manifest.open-wc.org/analyzer/getting-started/)
- [ ] Did you check the contributing doc?
- [ ] Did you check the existing issues for similar queries?

### Describe your PR

# @cldcvr/flow-core

## [2.6.1] - 2023-12-04

### Bug fixes

- re-exporting types of `f-input-base` from `f-input`. (To fix component type generation bug).

<img width="1029" alt="Screenshot 2023-12-04 at 7 04 02 PM" src="https://github.com/cldcvr/flow-core/assets/67629551/bff266bd-7483-4a6f-827f-0e879c498a2d">
